### PR TITLE
Fix model initialization validation

### DIFF
--- a/src/pass.js
+++ b/src/pass.js
@@ -103,8 +103,7 @@ class Pass {
 				// list without dynamic components like manifest, signature or pass files (will be added later in the flow) and hidden files.
 				let noDynList = removeHidden(modelFileList).filter(f => !/(manifest|signature|pass)/i.test(f));
 
-				if (!noDynList.length || !noDynList.some(f => f.toLowerCase().includes("icon"))
-					|| !remoteFilesList.some(f => f.toLowerCase().includes("icon"))) {
+				if (!noDynList.length || ![...noDynList, ...remoteFilesList].some(f => f.toLowerCase().includes("icon"))) {
 					let eMessage = formatError("MODEL_UNINITIALIZED", path.parse(this.model).name);
 					throw new Error(eMessage);
 				}


### PR DESCRIPTION
This PR addresses #4 whereby even if an icon was provided in the template, the model validation was failing erroneously since it expected an icon in remote files as well. This change updates the model validation logic to check for the existence of at least one icon file in either `noDynList` or `remoteFilesList`.