### PR TITLE
fix: check both static list and remote list before raising error

### DIFF
--- a/src/pass.js
+++ b/src/pass.js
@@ -104,8 +104,9 @@ class Pass {
 			.then(([modelFileList, remoteFilesList, remoteBuffers]) => {
 				// list without dynamic components like manifest, signature or pass files (will be added later in the flow) and hidden files.
 				let noDynList = removeHidden(modelFileList).filter(f => !/(manifest|signature|pass)/i.test(f));
+				const hasAssets = noDynList.length || remoteFilesList.length;
 
-				if (!noDynList.length || ![...noDynList, ...remoteFilesList].some(f => f.toLowerCase().includes("icon"))) {
+				if (!hasAssets || ![...noDynList, ...remoteFilesList].some(f => f.toLowerCase().includes("icon"))) {
 					let eMessage = formatMessage("MODEL_UNINITIALIZED", path.parse(this.model).name);
 					throw new Error(eMessage);
 				}


### PR DESCRIPTION
@alexandercerutti please take a look on this MR. My case: I don't have anything in pass folder beside my `pass.json` file. All required icons I do using `load` API since icons are different for different events. In current master version I am getting error, although I specify all required data