### PR TITLE
Improve Debug information

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ let examplePass = new Pass({
 });
 
 // Adding some settings to be written inside pass.json
-pass.localize("en", { ... });
-pass.barcode("36478105430"); // Random value
+examplePass.localize("en", { ... });
+examplePass.barcode("36478105430"); // Random value
 
 // Generate the stream, which gets returned through a Promise
-pass.generate()
+examplePass.generate()
 	.then(stream => {
 		doSomethingWithTheStream(stream);
 	})

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ examplePass.generate()
 
 ___
 
+## Debug
+
+In case of errors, more information about the nature of the error can be obtained by adding  `DEBUG=*` before invoking Node.
+
+E.g. `DEBUG=* node yourapp.js`
+
 ## Other
 
 If you used this package in any of your projects, feel free to open a topic in issues to tell me and include a project description or link (for companies). 😊 You'll make me feel like my time hasn't been wasted, even if it had not anyway because I learnt a lot of things by creating this.

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,13 +1,13 @@
 const errors = {
-	PASSFILE_VALIDATION_FAILED: "Validation of pass type failed. Pass file is not a valid buffer or (more probabily) does not respect the schema. Refer to https://apple.co/2Nvshvn to build a correct pass.",
-	REQUIR_VALID_FAILED: "The options passed to Pass constructor does not meet the requirements. Refer to the documentation to compile them correctly.",
-	MODEL_UNINITIALIZED: "Provided model ( %s ) matched but unitialized or may not contain icon. Refer to https://apple.co/2IhJr0Q, https://apple.co/2Nvshvn and documentation to fill the model correctly.",
+	PASSFILE_VALIDATION_FAILED: "Validation of pass type failed. Pass file is not a valid buffer or (more probably) does not respect the schema. \nRefer to https://apple.co/2Nvshvn to build a correct pass.\nDebug through `DEBUG=* node yourapp.js` to get more information about the error.",
+	REQUIR_VALID_FAILED: "The options passed to Pass constructor does not meet the requirements. \nRefer to the documentation to compile them correctly.",
+	MODEL_UNINITIALIZED: "Provided model ( %s ) matched but unitialized or may not contain icon. \nRefer to https://apple.co/2IhJr0Q, https://apple.co/2Nvshvn and documentation to fill the model correctly.",
 	MODEL_NOT_STRING: "A string model name must be provided in order to continue.",
 	MODEL_NOT_FOUND: "Model %s not found. Provide a valid one to continue.",
-	INVALID_CERTS: "Invalid certificate(s) loaded: %s. Please provide valid WWDR certificates and developer signer certificate and key (with passphrase). Refer to docs to obtain them.",
+	INVALID_CERTS: "Invalid certificate(s) loaded: %s. Please provide valid WWDR certificates and developer signer certificate and key (with passphrase). \nRefer to docs to obtain them.",
 	INVALID_CERT_PATH: "Invalid certificate loaded. %s does not exist.",
 	TRSTYPE_REQUIRED: "Cannot proceed with pass creation. transitType field is required for boardingPasses.",
-	OVV_KEYS_BADFORMAT: "Cannot proceed with pass creation due to bad keys format in overrides. Debug the app through `DEBUG=* node yourapp.js` to get more information about the error."
+	OVV_KEYS_BADFORMAT: "Cannot proceed with pass creation due to bad keys format in overrides. \nDebug the app through `DEBUG=* node yourapp.js` to get more information about the error."
 };
 
 const debugMessages = {


### PR DESCRIPTION
**_Motivation:_** 
While working with the passkit-generator I experienced some issues and not everything went smooth. This was mostly to not perfectly clear documentation (pretty awesome for a hobby project though) and how to debug the framework.

**_Contains:_** 
- an updated README with a section for debugging
- clearer instructions and debug usage when pass validation fails
- fixed a spelling error in messages.js
- corrected an error in the README pass->examplePass

_// if you want a specific template for PRs please let me know_