### PR TITLE
fix: await for _remoteResources.reduce to resolve

### DIFF
--- a/src/pass.js
+++ b/src/pass.js
@@ -68,7 +68,7 @@ class Pass {
 			 * Getting the buffers for remote files
 			 */
 
-			const buffersPromise = this._remoteResources.reduce(async (acc, current) => {
+			const buffersPromise = await this._remoteResources.reduce(async (acc, current) => {
 				try {
 					const response = await got(current[0], { encoding: null });
 					loadDebug(formatMessage("LOAD_MIME", response.headers["content-type"]));
@@ -100,7 +100,7 @@ class Pass {
 			}
 
 			// list without localization files (they will be added later in the flow)
-			const bundle = noDynList.filter(f => !f.includes(".lproj"));
+			let bundle = noDynList.filter(f => !f.includes(".lproj"));
 
 			// Localization folders only
 			const L10N = noDynList.filter(f => f.includes(".lproj") && Object.keys(this.l10n).includes(path.parse(f).name));


### PR DESCRIPTION
Hey @alexandercerutti,
Here is my fix for issue #19 

I added an await for the `_remoteResources` in order to spread it to the `buffers` var.
I also changed `const bundle = ...` to `let bundle = ...` as it is being manipulated with push lower down.

Closes #19 