### PR TITLE
Adding support for native Dates

### DIFF
--- a/spec/index.js
+++ b/spec/index.js
@@ -91,6 +91,14 @@ describe("Node-Passkit-generator", function () {
 			expect(noTimeZoneDateTime).toBe("2021-04-10T00:00:00");
 		});
 
+		it("A date as a Date object will apply changes", () => {
+			pass.expiration(new Date(2020,5,1,0,0,0));
+			// this is made to avoid problems with winter and summer time:
+			// we focus only on the date and time for the tests.
+			let noTimeZoneDateTime = pass._props["expirationDate"].split("+")[0];
+			expect(noTimeZoneDateTime).toBe("2020-06-01T00:00:00");
+		});
+
 		it("An invalid date, will not apply changes", () => {
 			pass.expiration("32/18/228317");
 			expect(pass._props["expirationDate"]).toBe(undefined);
@@ -125,6 +133,14 @@ describe("Node-Passkit-generator", function () {
 				let noTimeZoneDateTime = pass._props["relevantDate"].split("+")[0];
 				expect(noTimeZoneDateTime).toBe("2021-04-10T00:00:00");
 			});
+
+			it("A date as a Date object will apply changes", () => {
+				pass.relevance("relevantDate",new Date(2020,5,1,0,0,0));
+				// this is made to avoid problems with winter and summer time:
+				// we focus only on the date and time for the tests.
+				let noTimeZoneDateTime = pass._props["relevantDate"].split("+")[0];
+				expect(noTimeZoneDateTime).toBe("2020-06-01T00:00:00");
+			});			
 		});
 
 		describe("relevance('maxDistance')", () => {

--- a/src/pass.js
+++ b/src/pass.js
@@ -256,7 +256,7 @@ class Pass {
 	 */
 
 	expiration(date, format) {
-		if (typeof date !== "string" && !date instanceof Date) {
+		if (typeof date !== "string" && !(date instanceof Date)) {
 			return this;
 		}
 
@@ -324,7 +324,7 @@ class Pass {
 
 			return assignLength(Number(!cond), this);
 		} else if (type === "relevantDate") {
-			if (typeof data !== "string" && !data instanceof Date) {
+			if (typeof data !== "string" && !(data instanceof Date)) {
 				genericDebug(formatMessage("DATE_FORMAT_UNMATCH", "Relevant Date"));
 				return this;
 			}

--- a/src/pass.js
+++ b/src/pass.js
@@ -256,7 +256,7 @@ class Pass {
 	 */
 
 	expiration(date, format) {
-		if (typeof date !== "string") {
+		if (typeof date !== "string" && !date instanceof Date) {
 			return this;
 		}
 
@@ -324,6 +324,11 @@ class Pass {
 
 			return assignLength(Number(!cond), this);
 		} else if (type === "relevantDate") {
+			if (typeof data !== "string" && !data instanceof Date) {
+				genericDebug(formatMessage("DATE_FORMAT_UNMATCH", "Relevant Date"));
+				return this;
+			}
+			
 			let dateParse = dateToW3CString(data, relevanceDateFormat);
 
 			if (!dateParse) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,7 +34,7 @@ function isValidRGB(value) {
  */
 
 function dateToW3CString(date, format) {
-	if (typeof date !== "string" && !date instanceof Date) {
+	if (typeof date !== "string" && !(date instanceof Date)) {
 		return "";
 	}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -34,11 +34,11 @@ function isValidRGB(value) {
  */
 
 function dateToW3CString(date, format) {
-	if (typeof date !== "string") {
+	if (typeof date !== "string" && !date instanceof Date) {
 		return "";
 	}
 
-	const parsedDate = moment(date.replace(/\//g, "-"), format || ["MM-DD-YYYY hh:mm:ss", "DD-MM-YYYY hh:mm:ss"]).format();
+	const parsedDate = date instanceof Date ? moment(date).format() : moment(date.replace(/\//g, "-"), format || ["MM-DD-YYYY hh:mm:ss", "DD-MM-YYYY hh:mm:ss"]).format();
 
 	if (parsedDate === "Invalid date") {
 		return undefined;


### PR DESCRIPTION
Pass.js
----------
Added check in expiration function to permit date type of Date as well as string
Added check for date type into relevance function (no date check previously)

Utils.js
----------
Added a similar date type check to that in pass.js
Modified creation of parseDate to skip the parse step if date is a Date rather than a string.

Possible improvement: As it stands, [I suspect that] you cannot pass in a Date as a Moment object.
A small change to the date check should permit that.