### PR TITLE
Feature: support for overriding 'organizationName' field

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -66,6 +66,7 @@ const instance = Joi.object().keys({
 export interface OverridesSupportedOptions {
 	serialNumber?: string;
 	description?: string;
+	organizationName?: string;
 	userInfo?: Object | Array<any>;
 	webServiceURL?: string;
 	authenticationToken?: string;
@@ -82,6 +83,7 @@ export interface OverridesSupportedOptions {
 const supportedOptions = Joi.object().keys({
 	serialNumber: Joi.string(),
 	description: Joi.string(),
+	organizationName: Joi.string(),
 	userInfo: Joi.alternatives(Joi.object().unknown(), Joi.array()),
 	// parsing url as set of words and nums followed by dots, optional port and any possible path after
 	webServiceURL: Joi.string().regex(/https?:\/\/(?:[a-z0-9]+\.?)+(?::\d{2,})?(?:\/[\S]+)*/),


### PR DESCRIPTION
Hello!

First of all thanks for great library.
In our project we need to use different organization names so we have to override default pass.json property. Looks like your project doesn't have this ability.
We fixed it pretty easily with 'organizationName' property in 'OverridesSupportedOptions' interface and 'supportedOptions' object. 

Here is simple pull request, looking forward to your response!