### PR TITLE
Fix invalid path for build on windows

### DIFF
--- a/src/getModelFolderContents.ts
+++ b/src/getModelFolderContents.ts
@@ -107,7 +107,7 @@ function getObjectFromModelFile(
 	const fileComponents = filePath.split(path.sep);
 	const fileName = fileComponents
 		.slice(fileComponents.length - depthFromEnd)
-		.join(path.sep);
+		.join('/');
 
 	return { [fileName]: content };
 }


### PR DESCRIPTION
Pass kit generation from directory on windows seems to be broken for localization directories
```json
{
	"strip.png": "20ebdcb75f9147ce47b680bbabf63f3eb9f213a2",
	"pass.json": "9afd10517e71b870396dd1c000329577f934aa09",
	"logo.png": "24f112d1c69624f6800dd6c3db4d64adc0b5e697",
	"icon.png": "24f112d1c69624f6800dd6c3db4d64adc0b5e697",
	"fr.lproj\\pass.strings": "0a844bb88c39c3c19e31470b2627af2c66959826",
	"en.lproj\\pass.strings": "0a844bb88c39c3c19e31470b2627af2c66959826"
}
```
It causes the pass to be unrecognized by iOS/iMac (`\\` should be `/`)

Code that should create invalid `manifest.json` on windows with Node.JS v16.13.1
```js

const genPass = (uuid) => {
    let path = `${uuid}.pkpass`;
    PKPass.from(
        {
            model: 'test.pass',
            certificates: {
                signerCert: fs.readFileSync('pass.pem'),
                signerKey: fs.readFileSync('key.key'),
                wwdr: fs.readFileSync('wwdr.pem'),
                signerKeyPassphrase: process.env.PASSPHRASE,
            }
        },
        {
            serialNumber: uuid,
        }
    ).then((pass) => {
        pass.setBarcodes({
            message: uuid,
            format: "PKBarcodeFormatCode128"
        })
        fs.writeFileSync(path, pass.getAsBuffer())
    });
    return path;
}
```