### PR TITLE
Check for Joi.binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
 		"build:src": "rimraf lib && npx tsc -p tsconfig.dist.json",
 		"build:spec": "rimraf \"./spec/*.!(ts)\" && npx tsc -p tsconfig.spec.json",
 		"prepublishOnly": "npm run build",
-		"test": "npm run build:spec && npx jasmine",
-		"prepare": "npm run build"
+		"test": "npm run build:spec && npx jasmine"
 	},
 	"author": "Alexander Patrick Cerutti",
 	"license": "MIT",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"build:src": "rimraf lib && npx tsc -p tsconfig.dist.json",
 		"build:spec": "rimraf \"./spec/*.!(ts)\" && npx tsc -p tsconfig.spec.json",
 		"prepublishOnly": "npm run build",
-		"test": "npm run build:spec && npx jasmine"
+		"test": "npm run build:spec && npx jasmine",
+		"prepare": "npm run build"
 	},
 	"author": "Alexander Patrick Cerutti",
 	"license": "MIT",

--- a/src/schemas/Certificates.ts
+++ b/src/schemas/Certificates.ts
@@ -8,11 +8,14 @@ export interface CertificatesSchema {
 	signerKeyPassphrase?: string;
 }
 
+// Joi.binary is not available in the browser
+const maybeBinaryOrString = Joi.binary ? [Joi.binary(), Joi.string()] : [Joi.string()];
+
 export const CertificatesSchema = Joi.object<CertificatesSchema>()
 	.keys({
-		wwdr: Joi.alternatives(Joi.binary(), Joi.string()).required(),
-		signerCert: Joi.alternatives(Joi.binary(), Joi.string()).required(),
-		signerKey: Joi.alternatives(Joi.binary(), Joi.string()).required(),
+		wwdr: Joi.alternatives(...maybeBinaryOrString).required(),
+		signerCert: Joi.alternatives(...maybeBinaryOrString).required(),
+		signerKey: Joi.alternatives(...maybeBinaryOrString).required(),
 		signerKeyPassphrase: Joi.string(),
 	})
 	.required();

--- a/src/schemas/Certificates.ts
+++ b/src/schemas/Certificates.ts
@@ -8,14 +8,14 @@ export interface CertificatesSchema {
 	signerKeyPassphrase?: string;
 }
 
-// Joi.binary is not available in the browser
-const maybeBinaryOrString = Joi.binary ? [Joi.binary(), Joi.string()] : [Joi.string()];
+// Joi.binary is not available in the browser so fallback to basic check
+const binary = Joi.binary ? Joi.binary() : Joi.custom((obj) => Buffer.isBuffer(obj));
 
 export const CertificatesSchema = Joi.object<CertificatesSchema>()
 	.keys({
-		wwdr: Joi.alternatives(...maybeBinaryOrString).required(),
-		signerCert: Joi.alternatives(...maybeBinaryOrString).required(),
-		signerKey: Joi.alternatives(...maybeBinaryOrString).required(),
+		wwdr: Joi.alternatives(binary, Joi.string()).required(),
+		signerCert: Joi.alternatives(binary, Joi.string()).required(),
+		signerKey: Joi.alternatives(binary, Joi.string()).required(),
 		signerKeyPassphrase: Joi.string(),
 	})
 	.required();

--- a/src/schemas/Certificates.ts
+++ b/src/schemas/Certificates.ts
@@ -8,7 +8,7 @@ export interface CertificatesSchema {
 	signerKeyPassphrase?: string;
 }
 
-// Joi.binary is not available in the browser so fallback to basic check
+// Joi.binary is not available in browser-like environments (like Cloudflare workers) so fallback to basic check
 const binary = Joi.binary ? Joi.binary() : Joi.custom((obj) => Buffer.isBuffer(obj));
 
 export const CertificatesSchema = Joi.object<CertificatesSchema>()


### PR DESCRIPTION
Per this release https://github.com/sideway/joi/issues/2037#:~:text=The%20browser%20build%20does%20not%20include%20TLD%20email%20validation%2C%20Joi.binary()%2C%20the%20describe/build%20functionality%2C%20or%20debug/tracing. Joi.binary doesn't work in the browser and yield an error as follows:

![image](https://user-images.githubusercontent.com/6671020/151848480-9114d178-e3c5-45d1-95cc-785ed17e2e9e.png)
