### PR TITLE
Missing extension in minimal example

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ try {
 	const { wwdr, signerCert, signerKey, signerKeyPassphrase } = getCertificatesContentsSomehow();
 
 	const examplePass = new PKPass({
-		"thumbnail": Buffer.from([ ... ]),
-		"icon": Buffer.from([ ... ]),
+		"thumbnail.png": Buffer.from([ ... ]),
+		"icon.png": Buffer.from([ ... ]),
 		"pass.json": Buffer.from([ ... ]),
 		"it.lproj/pass.strings": Buffer.from([ ... ])
 	},


### PR DESCRIPTION
Without .png extension it wont work. The pass will be created but opening is failing, because the icon is saved inside the zip without any extension.