### PR TITLE
Fixed FieldsArray.push to preserve the order of input items

### DIFF
--- a/spec/FieldsArray.ts
+++ b/spec/FieldsArray.ts
@@ -40,6 +40,15 @@ describe("FieldsArray", () => {
 			expect(fa[0]).toEqual({ key: "t1", value: "v1" });
 		});
 
+		it("should preserve order of input items when adding fields", () => {
+			expect(
+				fa.push({ key: "t1", value: "v1" }, { key: "t2", value: "v2" })
+			).toBe(2);
+			expect(fa.length).toBe(2);
+			expect(fa[0]).toEqual({ key: "t1", value: "v1" });
+			expect(fa[1]).toEqual({ key: "t2", value: "v2" });
+		});
+
 		it("should add the key to the pool", () => {
 			fa.push({ key: "t1", value: "v1" });
 

--- a/src/FieldsArray.ts
+++ b/src/FieldsArray.ts
@@ -67,7 +67,7 @@ function registerWithValidation(
 
 	let validItems: Schemas.Field[] = [];
 
-	for (let i = items.length, field: Schemas.Field; (field = items[--i]); ) {
+	for (const field of items) {
 		try {
 			Schemas.assertValidity(
 				Schemas.Field,


### PR DESCRIPTION
PR to fix the reported issue: https://github.com/alexandercerutti/passkit-generator/issues/103

> In the generated passes, the fields (eg: primaryFields, secondaryFields) appear in reverse order compared to the original source in pass.json.

Fixes #103 