### PR TITLE
making either value or attributed value required

### DIFF
--- a/src/schemas/Field.ts
+++ b/src/schemas/Field.ts
@@ -71,4 +71,4 @@ export const Field = Joi.object<Field>().keys({
 			is: Joi.number(),
 			otherwise: Joi.string().forbidden(),
 		}),
-}).or('value', 'attributedValue');
+}).or("value", "attributedValue");

--- a/src/schemas/Field.ts
+++ b/src/schemas/Field.ts
@@ -45,7 +45,7 @@ export const Field = Joi.object<Field>().keys({
 		Joi.string().allow(""),
 		Joi.number(),
 		Joi.date().iso(),
-	).required(),
+	),
 	semantics: Semantics,
 	// date fields formatters, all optionals
 	dateStyle: Joi.string().regex(
@@ -71,4 +71,4 @@ export const Field = Joi.object<Field>().keys({
 			is: Joi.number(),
 			otherwise: Joi.string().forbidden(),
 		}),
-});
+}).or('value', 'attributedValue');


### PR DESCRIPTION
## Description

Some passes contain only an `attributedValue` in place of the `value` field on the `backFields` object, which the current build does not allow for as it always requires `value` to be present. This change makes either field required.

## Check relevant checkboxes

-   [X] I've run tests (through `npm test`) and they passed
-   [X] I generated a working Apple Wallet Pass after the change
-   [X] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

## Relevant information
Example error print when you leave off both fields

```
Cannot add pass.json to bundle because it is invalid. ValidationError: "generic.backFields[0]" must contain at least one of [value, attributedValue]
```

[JOI or documentation](https://joi.dev/api/?v=17.6.0#objectorpeers-options)
