### PR TITLE
Fix to unsupported fields rows

### DIFF
--- a/examples/models/examplePass.pass/pass.json
+++ b/examples/models/examplePass.pass/pass.json
@@ -41,6 +41,20 @@
 				"label": "LOCATION",
 				"value": "Moscone West"
 			}
+		],
+		"auxiliaryFields": [
+			{
+				"key": "Foo",
+				"value": "foo2",
+				"label": "Foo(l)",
+				"row": 0
+			},
+			{
+				"key": "Foo2",
+				"value": "foo3",
+				"label": "Foo(l)2",
+				"row": 1
+			}
 		]
 	}
 }

--- a/src/FieldsArray.ts
+++ b/src/FieldsArray.ts
@@ -10,6 +10,7 @@ import * as Messages from "./messages";
 
 const passInstanceSymbol = Symbol("passInstance");
 const sharedKeysPoolSymbol = Symbol("keysPool");
+const fieldSchemaSymbol = Symbol("fieldSchema");
 
 export default class FieldsArray extends Array<Schemas.Field> {
 	private [passInstanceSymbol]: InstanceType<typeof PKPass>;
@@ -18,9 +19,11 @@ export default class FieldsArray extends Array<Schemas.Field> {
 	constructor(
 		passInstance: InstanceType<typeof PKPass>,
 		keysPool: Set<string>,
+		fieldSchema: typeof Schemas.Field | typeof Schemas.FieldWithRow,
 		...args: Schemas.Field[]
 	) {
 		super(...args);
+		this[fieldSchemaSymbol] = fieldSchema;
 		this[passInstanceSymbol] = passInstance;
 		this[sharedKeysPoolSymbol] = keysPool;
 	}
@@ -75,7 +78,7 @@ function registerWithValidation(
 
 		try {
 			Schemas.assertValidity(
-				Schemas.Field,
+				instance[fieldSchemaSymbol],
 				field,
 				Messages.FIELDS.INVALID,
 			);

--- a/src/PKPass.ts
+++ b/src/PKPass.ts
@@ -353,12 +353,32 @@ export default class PKPass extends Bundle {
 		const sharedKeysPool = new Set<string>();
 
 		this[passTypeSymbol] = type;
-		this[propsSymbol][this[passTypeSymbol]] = {
-			headerFields /******/: new FieldsArray(this, sharedKeysPool),
-			primaryFields /*****/: new FieldsArray(this, sharedKeysPool),
-			secondaryFields /***/: new FieldsArray(this, sharedKeysPool),
-			auxiliaryFields /***/: new FieldsArray(this, sharedKeysPool),
-			backFields /********/: new FieldsArray(this, sharedKeysPool),
+		this[propsSymbol][type] = {
+			headerFields /******/: new FieldsArray(
+				this,
+				sharedKeysPool,
+				Schemas.Field,
+			),
+			primaryFields /*****/: new FieldsArray(
+				this,
+				sharedKeysPool,
+				Schemas.Field,
+			),
+			secondaryFields /***/: new FieldsArray(
+				this,
+				sharedKeysPool,
+				Schemas.Field,
+			),
+			auxiliaryFields /***/: new FieldsArray(
+				this,
+				sharedKeysPool,
+				type === "eventTicket" ? Schemas.FieldWithRow : Schemas.Field,
+			),
+			backFields /********/: new FieldsArray(
+				this,
+				sharedKeysPool,
+				Schemas.Field,
+			),
 			transitType: undefined,
 		};
 	}

--- a/src/PKPass.ts
+++ b/src/PKPass.ts
@@ -287,9 +287,14 @@ export default class PKPass extends Bundle {
 	 * if no valid pass.json has been parsed yet
 	 * or, anyway, if a valid type has not been
 	 * set yet.
+	 *
+	 * For Typescript users: this signature allows
+	 * in any case to add the 'row' field, but on
+	 * runtime they are only allowed on "eventTicket"
+	 * passes.
 	 */
 
-	public get auxiliaryFields(): Schemas.Field[] {
+	public get auxiliaryFields(): Schemas.FieldWithRow[] {
 		return this[propsSymbol][this.type].auxiliaryFields;
 	}
 

--- a/src/schemas/Field.ts
+++ b/src/schemas/Field.ts
@@ -22,6 +22,10 @@ export interface Field {
 	numberStyle?: string;
 }
 
+export interface FieldWithRow extends Field {
+	row?: 0 | 1;
+}
+
 export const Field = Joi.object<Field>().keys({
 	attributedValue: Joi.alternatives(
 		Joi.string().allow(""),
@@ -72,3 +76,9 @@ export const Field = Joi.object<Field>().keys({
 			otherwise: Joi.string().forbidden(),
 		}),
 });
+
+export const FieldWithRow = Field.concat(
+	Joi.object<FieldWithRow>().keys({
+		row: Joi.number().min(0).max(1),
+	}),
+);

--- a/src/schemas/PassFields.ts
+++ b/src/schemas/PassFields.ts
@@ -1,5 +1,5 @@
 import Joi from "joi";
-import { Field } from "./Field";
+import { Field, FieldWithRow } from "./Field";
 
 export type TransitType =
 	| "PKTransitTypeAir"
@@ -13,7 +13,7 @@ export const TransitType = Joi.string().regex(
 );
 
 export interface PassFields {
-	auxiliaryFields: (Field & { row?: number })[];
+	auxiliaryFields: FieldWithRow[];
 	backFields: Field[];
 	headerFields: Field[];
 	primaryFields: Field[];
@@ -22,13 +22,7 @@ export interface PassFields {
 }
 
 export const PassFields = Joi.object<PassFields>().keys({
-	auxiliaryFields: Joi.array().items(
-		Joi.object()
-			.keys({
-				row: Joi.number().max(1).min(0),
-			})
-			.concat(Field),
-	),
+	auxiliaryFields: Joi.array().items(FieldWithRow),
 	backFields: Joi.array().items(Field),
 	headerFields: Joi.array().items(Field),
 	primaryFields: Joi.array().items(Field),


### PR DESCRIPTION
<!--
	Thank you for your contribution to passkit-generator.
	You'll be responded to as soon as possible. (but I
	assure you will be responded! 😉)

	Meanwhile, what about leaving a ⭐️ on the project? That
	would be very helpful for making it even more known. 🔝
-->

## Description

Fixes #115
Fixes #116

## Check relevant checkboxes

-   [x] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [x] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

## Relevant information

@danawoodman I generated a valid pass with two rows. Let me know if this fixes correctly the issue! 👍
