### PR TITLE
Set Semantic.wifiAccess as array type

### DIFF
--- a/src/schemas/Semantics.ts
+++ b/src/schemas/Semantics.ts
@@ -176,7 +176,7 @@ export interface Semantics {
 	venuePhoneNumber?: string;
 	venueRoom?: string;
 
-	wifiAccess?: SemanticTagType.WifiNetwork;
+	wifiAccess?: SemanticTagType.WifiNetwork[];
 }
 
 export const Semantics = Joi.object<Semantics>().keys({


### PR DESCRIPTION
## Description

See #135 for background and details.

## Check relevant checkboxes

-   [x] I've run tests (through `npm test`) and they passed – ⚠️ Test failed even without my change. Not sure if it's a local problem see below for output
-   [x] I generated a working Apple Wallet Pass after the change - ⚠️ Manually inspecting the generated `pass.json` there isn't any `wifiAccess` information present. 
-   [ ] Provided examples keep working after the change - ℹ️ Not tested.
-   [x] This improvement is or might be a breaking change - ⚠️ Yes, since this changes public API

## Notes

In Apple's own documentation it's very unclear where you should add `wifiAccess`. It looks like it's "supported" on all `headerFields`, `primaryFields`, `auxiliaryFields` and `backFields` which seems a bit weird. @alexandercerutti do you know?

🔗 [Relevant Apple documentation](https://developer.apple.com/documentation/walletpasses/pass/supporting_semantic_tags_in_wallet_passes)

## Failed test

```
passkit-generator git:(wifi-access-array-type) npm test                                                                                                                   git:(wifi-access-array-type|)

> passkit-generator@3.1.7 test
> npm run build:spec && npx jasmine


> passkit-generator@3.1.7 build:spec
> rimraf "./spec/*.!(ts)" && npx tsc -p tsconfig.spec.json

spec/FieldsArray.ts:13:8 - error TS2555: Expected at least 3 arguments, but got 2.

 13   fa = new FieldsArray(
           ~~~~~~~~~~~~~~~~
 14    {
    ~~~~
...
 19    pool,
    ~~~~~~~~
 20   );
    ~~~

  lib/FieldsArray.d.ts:12:83
    12     constructor(passInstance: InstanceType<typeof PKPass>, keysPool: Set<string>, fieldSchema: typeof Schemas.Field | typeof Schemas.FieldWithRow, ...args: Schemas.Field[]);
                                                                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'fieldSchema' was not provided.


Found 1 error in spec/FieldsArray.ts:13
```
