### PR TITLE
fix: transitType should be read when type is boardingPass

### DIFF
--- a/src/PKPass.ts
+++ b/src/PKPass.ts
@@ -556,6 +556,7 @@ export default class PKPass extends Bundle {
 				secondaryFields = [],
 				auxiliaryFields = [],
 				backFields = [],
+				transitType,
 			} = data[type] || {};
 
 			this.headerFields.push(...headerFields);
@@ -563,6 +564,9 @@ export default class PKPass extends Bundle {
 			this.secondaryFields.push(...secondaryFields);
 			this.auxiliaryFields.push(...auxiliaryFields);
 			this.backFields.push(...backFields);
+			if (this.type === "boardingPass") {
+				this.transitType = transitType;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
	Thank you for your contribution to passkit-generator.
	You'll be responded to as soon as possible. (but I
	assure you will be responded! 😉)

	Meanwhile, what about leaving a ⭐️ on the project? That
	would be very helpful for making it even more known. 🔝
-->

## Description

This closes #137 

## Check relevant checkboxes

-   [x] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [x] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change
