### PR TITLE
Fix Date to W3C string converter

### DIFF
--- a/specs/PKPass.spec.cjs
+++ b/specs/PKPass.spec.cjs
@@ -712,12 +712,12 @@ describe("PKPass", () => {
 
 	describe("expiration date", () => {
 		it("should set a pass expiration date", () => {
-			pkpass.setExpirationDate(new Date(2023, 3, 10));
+			pkpass.setExpirationDate(new Date("2023-04-09T17:00-07:00"));
 
 			const passjsonGenerated = getGeneratedPassJson(pkpass);
 
 			expect(passjsonGenerated.expirationDate).toBe(
-				"2023-04-10T00:00:00Z",
+				"2023-04-10T00:00:00.000Z",
 			);
 		});
 
@@ -808,11 +808,11 @@ describe("PKPass", () => {
 
 	describe("relevant date", () => {
 		it("should set pass relevant date", () => {
-			pkpass.setRelevantDate(new Date(2023, 3, 10, 14, 15));
+			pkpass.setRelevantDate(new Date("2023-04-11T00:15+10:00"));
 
 			const passjsonGenerated = getGeneratedPassJson(pkpass);
 
-			expect(passjsonGenerated.relevantDate).toBe("2023-04-10T14:15:00Z");
+			expect(passjsonGenerated.relevantDate).toBe("2023-04-10T14:15:00.000Z");
 		});
 
 		it("should reset relevant date", () => {

--- a/specs/utils.spec.cjs
+++ b/specs/utils.spec.cjs
@@ -32,8 +32,8 @@ describe("Utils", () => {
 		});
 
 		it("should convert a Date object to a valid W3C date", () => {
-			expect(processDate(new Date(2020, 6, 1, 0, 0, 0, 0))).toBe(
-				"2020-07-01T00:00:00Z",
+			expect(processDate(new Date("2020-07-01T02:00+02:00"))).toBe(
+				"2020-07-01T00:00:00.000Z",
 			);
 		});
 	});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,30 +36,7 @@ function dateToW3CString(date: Date) {
 		return undefined;
 	}
 
-	const paddedMonth = padMeTwo(date.getMonth() + 1);
-	const paddedDay = padMeTwo(date.getDate());
-	const paddedHour = padMeTwo(date.getHours());
-	const paddedMinutes = padMeTwo(date.getMinutes());
-	const paddedSeconds = padMeTwo(date.getSeconds());
-
-	/**
-	 * Date.prototype.getTimezoneOffset returns the timezone UTC offset in
-	 * minutes of the local machine.
-	 *
-	 * That value should then be used to calculate the effective timezone as
-	 * string, but still that would be related to the machine and not to the
-	 * specified date.
-	 *
-	 * For this reason we are completing date with "Z" TimeZoneDesignator (TZD)
-	 * to say it to use local timezone.
-	 *
-	 * In the future we might think to integrate another parameter to represent
-	 * a custom timezone.
-	 *
-	 * @see https://www.w3.org/TR/NOTE-datetime
-	 */
-
-	return `${date.getFullYear()}-${paddedMonth}-${paddedDay}T${paddedHour}:${paddedMinutes}:${paddedSeconds}Z`;
+	return date.toISOString();
 }
 
 function padMeTwo(original: string | number) {


### PR DESCRIPTION
<!--
	Thank you for your contribution to passkit-generator.
	You'll be responded to as soon as possible. (but I
	assure you will be responded! 😉)

	Meanwhile, what about leaving a ⭐️ on the project? That
	would be very helpful for making it even more known. 🔝
-->

## Description

Currently date conversion is not handled right if the timezone is different to UTC (Z).

**Example:**
I live in Germany (currently UTC+02:00). So if my local time is 12:00, it's 10:00 in UTC. The correct representation of this time as W3C (ISO 8601) string is `2023-08-08T10:00:00Z` or `2023-08-08T12:00:00+02:00`.

But if I call `dateToW3CString` with a date created with `new Date()` it's converted to `2023-08-08T12:00:00Z`. But thats 14:00 in my timezone. With `toISOString` it's correctly `2023-08-08T10:00:00.000Z`.

So instead of using this complex and incorrect way to convert a Date to a W3C (ISO 8601) string, we should use the built-in function `toISOString`.

<!--
	Write here below a description about what you are trying to change.
	Also include, if needed, any information about the platform you tested on.

	If this pull request attempts to close an already opened issue, use issue
	linkers identifiers like "Fixes #99", to link it automatically. See the
	identifiers at the following page:
	https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Check relevant checkboxes

-   [x] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [x] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

