### PR TITLE
fix: relax validation rules for `major` in beacons

### DIFF
--- a/src/schemas/Beacon.ts
+++ b/src/schemas/Beacon.ts
@@ -12,11 +12,7 @@ export interface Beacon {
 }
 
 export const Beacon = Joi.object<Beacon>().keys({
-	major: Joi.number()
-		.integer()
-		.positive()
-		.max(65535)
-		.greater(Joi.ref("minor")),
+	major: Joi.number().integer().min(0).max(65535),
 	minor: Joi.number().integer().min(0).max(65535),
 	proximityUUID: Joi.string().required(),
 	relevantText: Joi.string(),


### PR DESCRIPTION
## Description
Fixes #157 
This PR relaxes `major` validation in beacons.

## Check relevant checkboxes
-   [x] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [x] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

## Relevant information

Look at #157 for more information about the issue.
Example of a working pass: https://file.io/f1XIkfUuzC96