### PR TITLE
Add support for stripColor

### DIFF
--- a/examples/firebase/functions/src/index.ts
+++ b/examples/firebase/functions/src/index.ts
@@ -20,6 +20,7 @@ interface RequestWithBody extends functions.Request {
 		textColor: string;
 		backgroundColor: string;
 		labelColor: string;
+		stripColor: string;
 		relevantDate?: string;
 		expiryDate?: string;
 		relevantLocationLat?: number;

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -405,7 +405,7 @@ export type PassKindsProps = { [K in PassTypesProps]: PassProps[K] };
 
 export type PassColors = Pick<
 	OverridablePassProps,
-	"backgroundColor" | "foregroundColor" | "labelColor"
+	"backgroundColor" | "foregroundColor" | "labelColor" | "stripColor"
 >;
 
 export const PassPropsFromMethods = Joi.object<PassPropsFromMethods>({

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -101,6 +101,13 @@ export interface PassProps {
 	foregroundColor?: string;
 	labelColor?: string;
 
+	/**
+	 * Undocumented feature:
+	 * Color of primary fields value when
+	 * rendered on top of a strip.
+	 */
+	stripColor?: string;
+
 	nfc?: NFC;
 	beacons?: Beacon[];
 	barcodes?: Barcode[];
@@ -441,6 +448,7 @@ export const OverridablePassProps = Joi.object<OverridablePassProps>({
 	maxDistance: Joi.number().positive(),
 	authenticationToken: Joi.string().min(16),
 	labelColor: Joi.string().regex(RGB_HEX_COLOR_REGEX),
+	stripColor: Joi.string().regex(RGB_HEX_COLOR_REGEX),
 	backgroundColor: Joi.string().regex(RGB_HEX_COLOR_REGEX),
 	foregroundColor: Joi.string().regex(RGB_HEX_COLOR_REGEX),
 	associatedStoreIdentifiers: Joi.array().items(Joi.number()),


### PR DESCRIPTION
## Description

First of all, thanks for this library!

I was trying a lot of combinations and noticed that as soon as I set a strip image/buffer, the primary fields text is always rendered with a white color and did not follow the labelColor like I would expect. I stumped upon some places that mentioned "stripColor", tried it and it's indeed working. I couldn't get tests running on Windows 11 with Powershell unfortunately, I only got errors from jest (`SyntaxError: Cannot use import statement outside a module`).

Hope this change also can help others facing the same issue.

## Check relevant checkboxes

-   [ ] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [ ] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

## Relevant information

Sources I could find about "stripColor":
- https://stackoverflow.com/a/31485785
- https://github.com/tinovyatkin/pass-js/pull/306
- https://help.passkit.com/en/articles/4179700-passkit-smartpass-links
- https://docs.passkit.io/common/templates/#operation/Templates_createTemplate