### PR TITLE
Fix props output

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,11 @@ export function cloneRecursive<T extends Object>(object: T) {
 				objectCopy[key] = value.slice();
 
 				for (let j = 0; j < value.length; j++) {
-					objectCopy[key][j] = cloneRecursive(value[j]);
+					const item = value[j];
+					objectCopy[key][j] =
+						item && typeof item === "object"
+							? cloneRecursive(item)
+							: item;
 				}
 			} else {
 				objectCopy[key] = cloneRecursive(value);


### PR DESCRIPTION
<!--
	Thank you for your contribution to passkit-generator.
	You'll be responded to as soon as possible. (but I
	assure you will be responded! 😉)

	Meanwhile, what about leaving a ⭐️ on the project? That
	would be very helpful for making it even more known. 🔝
-->

## Description

<!--
	Write here below a description about what you are trying to change.
	Also include, if needed, any information about the platform you tested on.

	If this pull request attempts to close an already opened issue, use issue
	linkers identifiers like "Fixes #99", to link it automatically. See the
	identifiers at the following page:
	https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Hi, great library! 

This fixes an issue with the `cloneRecursive` utility function. It wasn't correctly handling arrays of primitives.

I encountered the issue when accessing `pass.props`, which we use to debug the resulting pass json without building the whole zip.

Fields such as:
`preferredStyleSchemes: ['posterEventTicket', 'eventTicket']`

were coming back as:
`
preferredStyleSchemes: [
    {
      "0": "p",
      "1": "o",
      "2": "s",
      "3": "t",
      "4": "e",
      "5": "r",
      "6": "E",
      "7": "v",
      "8": "e",
      "9": "n",
      "10": "t",
      "11": "T",
      "12": "i",
      "13": "c",
      "14": "k",
      "15": "e",
      "16": "t"
    },
    {
      "0": "e",
      "1": "v",
      "2": "e",
      "3": "n",
      "4": "t",
      "5": "T",
      "6": "i",
      "7": "c",
      "8": "k",
      "9": "e",
      "10": "t"
    }
  ]
`


## Check relevant checkboxes

-   [ ] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [x] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

## Relevant information

<!-- Add any other relevant details to the PR (test, technical details, ...) -->
