### PR TITLE
fix: Remove TLD check on Joi email schema for URLs

### DIFF
--- a/src/schemas/UpcomingPassInformation.ts
+++ b/src/schemas/UpcomingPassInformation.ts
@@ -114,7 +114,12 @@ const URLs = Joi.object<URLs>({
 	accessibilityURL: Joi.string().regex(URL_REGEX),
 	addOnURL: Joi.string().regex(URL_REGEX),
 	bagPolicyURL: Joi.string().regex(URL_REGEX),
-	contactVenueEmail: Joi.string().email(),
+	/**
+	 * Joi's email schema validates email TLDs and only allows TLDs that are registered in the IANA Registry.
+	 * This also requires NodeJS runtime to work (even though can be enabled client side, but discouraged)
+	 * Reference - https://github.com/hapijs/joi/issues/2390
+	 */
+	contactVenueEmail: Joi.string().email({ tlds: false }),
 	contactVenuePhoneNumber: Joi.string(),
 	contactVenueWebsite: Joi.string().regex(URL_REGEX),
 	directionsInformationURL: Joi.string().regex(URL_REGEX),


### PR DESCRIPTION
<!--
	Thank you for your contribution to passkit-generator.
	You'll be responded to as soon as possible. (but I
	assure you will be responded! 😉)

	Meanwhile, what about leaving a ⭐️ on the project? That
	would be very helpful for making it even more known. 🔝
-->

## Description

<!--
	Write here below a description about what you are trying to change.
	Also include, if needed, any information about the platform you tested on.

	If this pull request attempts to close an already opened issue, use issue
	linkers identifiers like "Fixes #99", to link it automatically. See the
	identifiers at the following page:
	https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Check relevant checkboxes

-   [x] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [x] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

## Relevant information

<!-- Add any other relevant details to the PR (test, technical details, ...) -->
This PR disables Joi's Email TLD checks. Please feel free to close this if this seems irrelevant but becuase of this, Cloudflare Worker builds are breaking. This change can restore CF workers usage.

The TLD checks aren't available on client side & when one tries to deploy on CF workers, the script throws an exception.

## Exception

Following is the exception that occurs in GitHub actions or local environment while trying to deploy a project using this library:

```bash
✘ [ERROR] A request to the Cloudflare API (/accounts/***/workers/scripts/api/versions) failed.
  
    Uncaught Error: Built-in TLD list disabled
      at null.<anonymous> (file:///home/runner/work/api/api/node_modules/joi/dist/joi-browser.min.js:1:129140) in e4.exports
      at o (file:///home/runner/work/api/api/node_modules/joi/dist/joi-browser.min.js:1:124435) in e4.exports
      at null.<anonymous> (file:///home/runner/work/api/api/node_modules/joi/dist/joi-browser.min.js:1:110679) in p3.addressOptions
      at null.<anonymous> (file:///home/runner/work/api/api/node_modules/joi/dist/joi-browser.min.js:1:102337) in method
      at null.<anonymous> (file:///home/runner/work/api/api/node_modules/passkit-generator/src/schemas/UpcomingPassInformation.ts:117:34)
     [code: 10021]
  
    
    If you think this is a bug, please open an issue at: https://github.com/cloudflare/workers-sdk/issues/new/choose
```

Thanks :)