### PR TITLE
Optional venuePlaceID on UpcomingPassInformation

### DIFF
--- a/src/schemas/UpcomingPassInformation.ts
+++ b/src/schemas/UpcomingPassInformation.ts
@@ -231,7 +231,7 @@ export interface UpcomingPassInformationEntry {
 
 	/** The semantic, machine-readable metadata about the upcoming pass information entry. */
 	semantics?: Semantics & {
-		venuePlaceID: string;
+		venuePlaceID?: string;
 	};
 
 	/**


### PR DESCRIPTION
<!--
	Thank you for your contribution to passkit-generator.
	You'll be responded to as soon as possible. (but I
	assure you will be responded! 😉)

	Meanwhile, what about leaving a ⭐️ on the project? That
	would be very helpful for making it even more known. 🔝
-->

## Description

This is re: https://github.com/alexandercerutti/passkit-generator/issues/249#issuecomment-3470813019
and version 3.5.3

I have working map and event guide tiles on the upcoming event details pages without providing a venuePlaceID, but that was made required in 3.5.3.

Other findings:
At least 1 backFields entry of any key/value is required to get the details pages.

<!--
	Write here below a description about what you are trying to change.
	Also include, if needed, any information about the platform you tested on.

	If this pull request attempts to close an already opened issue, use issue
	linkers identifiers like "Fixes #99", to link it automatically. See the
	identifiers at the following page:
	https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

## Check relevant checkboxes

-   [x] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [x] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

