### PR TITLE
Allow appLaunchURL to have any scheme

### DIFF
--- a/examples/models/examplePass.pass/pass.json
+++ b/examples/models/examplePass.pass/pass.json
@@ -4,6 +4,7 @@
 	"serialNumber": "nmyuxofgna",
 	"teamIdentifier": "F53WB8AE67",
 	"webServiceURL": "https://192.168.1.254:80/",
+	"appLaunchURL": "myapp://product?id=123",
 	"authenticationToken": "vxwxd7J8AlNNFPS8k0a0FfUFtq0ewzFdc",
 	"relevantDate": "2011-12-08T13:00-08:00",
 	"locations": [

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -639,7 +639,7 @@ export const OverridablePassProps = Joi.object<OverridablePassProps>({
 	logoText: Joi.string(),
 	description: Joi.string(),
 	serialNumber: Joi.string(),
-	appLaunchURL: Joi.string().regex(URL_REGEX),
+	appLaunchURL: Joi.string().uri(),
 	teamIdentifier: Joi.string(),
 	organizationName: Joi.string(),
 	passTypeIdentifier: Joi.string(),


### PR DESCRIPTION
<!--
	Thank you for your contribution to passkit-generator.
	You'll be responded to as soon as possible. (but I
	assure you will be responded! 😉)

	Meanwhile, what about leaving a ⭐️ on the project? That
	would be very helpful for making it even more known. 🔝
-->

## Description

<!--
	Write here below a description about what you are trying to change.
	Also include, if needed, any information about the platform you tested on.

	If this pull request attempts to close an already opened issue, use issue
	linkers identifiers like "Fixes #99", to link it automatically. See the
	identifiers at the following page:
	https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fix #262 by change the validation schema from http(s) regex to Joi.string().uri().

## Check relevant checkboxes

-   [x] I've run tests (through `npm test`) and they passed
-   [x] I generated a working Apple Wallet Pass after the change
-   [x] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

## Relevant information

<!-- Add any other relevant details to the PR (test, technical details, ...) -->
