### PR TITLE
Speed up pass generation ~50x by removing four pure-JS hot spots

### DIFF
--- a/examples/cloudflare-worker/package.json
+++ b/examples/cloudflare-worker/package.json
@@ -8,7 +8,7 @@
 		"example": "pnpm wrangler dev"
 	},
 	"dependencies": {
-		"passkit-generator": "workspace:*"
+		"passkit-generator": "workspace:@jericommerce/passkit-generator@*"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "^4.20250109.0",

--- a/examples/firebase/functions/package.json
+++ b/examples/firebase/functions/package.json
@@ -18,10 +18,10 @@
 		"firebase-admin": "^13.0.2",
 		"firebase-functions": "^6.2.0",
 		"tslib": "^2.8.1",
-		"passkit-generator": "workspace:*"
+		"passkit-generator": "workspace:@jericommerce/passkit-generator@*"
 	},
 	"peerDependencies": {
-		"passkit-generator": "workspace:*"
+		"passkit-generator": "workspace:@jericommerce/passkit-generator@*"
 	},
 	"devDependencies": {
 		"firebase-functions-test": "^3.4.0",

--- a/examples/self-hosted/package.json
+++ b/examples/self-hosted/package.json
@@ -12,12 +12,12 @@
 		"example:debug": "pnpm tsx --inspect-brk src/index.ts"
 	},
 	"peerDependencies": {
-		"passkit-generator": "workspace:*"
+		"passkit-generator": "workspace:@jericommerce/passkit-generator@*"
 	},
 	"dependencies": {
 		"express": "^5.0.1",
 		"node-fetch": "^3.2.3",
-		"passkit-generator": "workspace:*",
+		"passkit-generator": "workspace:@jericommerce/passkit-generator@*",
 		"tslib": "^2.7.0"
 	},
 	"devDependencies": {

--- a/examples/serverless/package.json
+++ b/examples/serverless/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"aws-sdk": "^2.1692.0",
 		"tslib": "^2.8.1",
-		"passkit-generator": "workspace:*"
+		"passkit-generator": "workspace:@jericommerce/passkit-generator@*"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "^8.10.147",

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -16,6 +16,16 @@ process.env.TZ = "UTC";
 
 export default {
 	moduleFileExtensions: ["js", "mjs", "cjs"],
+	/**
+	 * The specs import the package by its bare name, which used to resolve
+	 * through Node's self-reference on `name`. The package is published under
+	 * the @jericommerce scope, so that self-reference no longer matches. Map
+	 * the bare name back to the build to keep the specs identical to
+	 * upstream's.
+	 */
+	moduleNameMapper: {
+		"^passkit-generator$": "<rootDir>/lib/esm/index.js",
+	},
 	testEnvironment: "node",
 	testMatch: ["**/specs/**/*.spec.mjs"],
 	injectGlobals: false,

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
 		"Pass"
 	],
 	"dependencies": {
+		"asn1js": "^3.0.10",
 		"joi": "17.13.4",
-		"node-forge": "^1.4.0",
 		"tslib": "^2.7.0"
 	},
 	"engines": {
@@ -37,6 +37,7 @@
 		"do-not-zip": "^1.0.0",
 		"jest": "^29.7.0",
 		"jest-environment-node": "^29.7.0",
+		"node-forge": "^1.4.0",
 		"prettier": "^3.3.3",
 		"rimraf": "^4.4.1",
 		"tsconfig-to-dual-package": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 	"scripts": {
 		"build": "rm -rf lib && pnpm tsc -b tsconfig.esm.json tsconfig.cjs.json && pnpm build:dual",
 		"build:dual": "pnpm tsconfig-to-dual-package tsconfig.esm.json tsconfig.cjs.json",
+		"prepare": "rimraf lib && tsc -b tsconfig.esm.json tsconfig.cjs.json && tsconfig-to-dual-package tsconfig.esm.json tsconfig.cjs.json",
 		"build:all": "pnpm build && pnpm build:examples",
 		"prepublishOnly": "pnpm build && pnpm test",
 		"test": "NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" pnpm jest -c jest.config.mjs --silent"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "passkit-generator",
+	"name": "@jericommerce/passkit-generator",
 	"version": "3.5.8",
 	"description": "The easiest way to generate custom Apple Wallet passes in Node.js",
 	"main": "lib/cjs/index.js",
@@ -8,15 +8,18 @@
 	"scripts": {
 		"build": "rm -rf lib && pnpm tsc -b tsconfig.esm.json tsconfig.cjs.json && pnpm build:dual",
 		"build:dual": "pnpm tsconfig-to-dual-package tsconfig.esm.json tsconfig.cjs.json",
-		"prepare": "rimraf lib && tsc -b tsconfig.esm.json tsconfig.cjs.json && tsconfig-to-dual-package tsconfig.esm.json tsconfig.cjs.json",
 		"build:all": "pnpm build && pnpm build:examples",
 		"prepublishOnly": "pnpm build && pnpm test",
 		"test": "NODE_OPTIONS=\"--experimental-vm-modules --no-warnings\" pnpm jest -c jest.config.mjs --silent"
 	},
 	"author": "Alexander Patrick Cerutti",
 	"license": "MIT",
-	"repository": "https://github.com/alexandercerutti/passkit-generator",
+	"repository": "https://github.com/cuni0716/passkit-generator",
 	"bugs": "https://github.com/alexandercerutti/passkit-generator/issues",
+	"publishConfig": {
+		"registry": "https://registry.npmjs.org",
+		"access": "public"
+	},
 	"keywords": [
 		"Apple",
 		"Passkit",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"Pass"
 	],
 	"dependencies": {
-		"do-not-zip": "^1.0.0",
 		"joi": "17.13.4",
 		"node-forge": "^1.4.0",
 		"tslib": "^2.7.0"
@@ -33,9 +32,9 @@
 	},
 	"devDependencies": {
 		"@jest/globals": "^29.7.0",
-		"@types/do-not-zip": "^1.0.2",
 		"@types/node": "^16.11.26",
 		"@types/node-forge": "^1.3.11",
+		"do-not-zip": "^1.0.0",
 		"jest": "^29.7.0",
 		"jest-environment-node": "^29.7.0",
 		"prettier": "^3.3.3",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
 		"Pass"
 	],
 	"dependencies": {
+		"asn1js": "^3.0.10",
 		"joi": "17.4.2",
-		"node-forge": "^1.3.2",
 		"tslib": "^2.7.0"
 	},
 	"engines": {
@@ -37,6 +37,7 @@
 		"do-not-zip": "^1.0.0",
 		"jest": "^29.7.0",
 		"jest-environment-node": "^29.7.0",
+		"node-forge": "^1.3.2",
 		"prettier": "^3.3.3",
 		"rimraf": "^4.4.1",
 		"tsconfig-to-dual-package": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
 		"Pass"
 	],
 	"dependencies": {
-		"do-not-zip": "^1.0.0",
 		"joi": "17.4.2",
 		"node-forge": "^1.3.2",
 		"tslib": "^2.7.0"
@@ -33,9 +32,9 @@
 	},
 	"devDependencies": {
 		"@jest/globals": "^29.7.0",
-		"@types/do-not-zip": "^1.0.2",
 		"@types/node": "^16.11.26",
 		"@types/node-forge": "^1.3.11",
+		"do-not-zip": "^1.0.0",
 		"jest": "^29.7.0",
 		"jest-environment-node": "^29.7.0",
 		"prettier": "^3.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
   examples/cloudflare-worker:
     dependencies:
       passkit-generator:
-        specifier: workspace:*
+        specifier: workspace:@jericommerce/passkit-generator@*
         version: link:../..
     devDependencies:
       '@cloudflare/workers-types':
@@ -80,7 +80,7 @@ importers:
         specifier: ^6.2.0
         version: 6.2.0(firebase-admin@13.0.2(encoding@0.1.13))
       passkit-generator:
-        specifier: workspace:*
+        specifier: workspace:@jericommerce/passkit-generator@*
         version: link:../../..
       tslib:
         specifier: ^2.8.1
@@ -108,7 +108,7 @@ importers:
         specifier: ^3.2.3
         version: 3.3.2
       passkit-generator:
-        specifier: workspace:*
+        specifier: workspace:@jericommerce/passkit-generator@*
         version: link:../..
       tslib:
         specifier: ^2.7.0
@@ -136,7 +136,7 @@ importers:
         specifier: ^2.1692.0
         version: 2.1692.0
       passkit-generator:
-        specifier: workspace:*
+        specifier: workspace:@jericommerce/passkit-generator@*
         version: link:../..
       tslib:
         specifier: ^2.8.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      do-not-zip:
-        specifier: ^1.0.0
-        version: 1.0.0
       joi:
         specifier: 17.13.4
         version: 17.13.4
@@ -24,15 +21,15 @@ importers:
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
-      '@types/do-not-zip':
-        specifier: ^1.0.2
-        version: 1.0.2
       '@types/node':
         specifier: ^16.11.26
         version: 16.18.124
       '@types/node-forge':
         specifier: ^1.3.11
         version: 1.3.11
+      do-not-zip:
+        specifier: ^1.0.0
+        version: 1.0.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
@@ -1654,9 +1651,6 @@ packages:
 
   '@types/cors@2.8.17':
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
-
-  '@types/do-not-zip@1.0.2':
-    resolution: {integrity: sha512-J978lrQQD67I42aI/r1NusHmeQbBbf00WK05/r8p6Tbh7mTmWqgU0fjf8ZQ30jRgzBGYmJR/wuL9IhRU5h2mMA==}
 
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
@@ -8746,10 +8740,6 @@ snapshots:
       '@types/node': 20.17.14
 
   '@types/cors@2.8.17':
-    dependencies:
-      '@types/node': 20.17.14
-
-  '@types/do-not-zip@1.0.2':
     dependencies:
       '@types/node': 20.17.14
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,12 @@ importers:
 
   .:
     dependencies:
+      asn1js:
+        specifier: ^3.0.10
+        version: 3.0.10
       joi:
         specifier: 17.13.4
         version: 17.13.4
-      node-forge:
-        specifier: ^1.4.0
-        version: 1.4.0
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
@@ -36,6 +36,9 @@ importers:
       jest-environment-node:
         specifier: ^29.7.0
         version: 29.7.0
+      node-forge:
+        specifier: ^1.4.0
+        version: 1.4.0
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -1054,6 +1057,9 @@ packages:
   '@hapi/hoek@11.0.7':
     resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
 
+  '@hapi/hoek@9.1.1':
+    resolution: {integrity: sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==}
+
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
 
@@ -1120,6 +1126,9 @@ packages:
   '@hapi/teamwork@6.0.0':
     resolution: {integrity: sha512-05HumSy3LWfXpmJ9cr6HzwhAavrHkJ1ZRCmNE2qJMihdM5YcWreWPfyN0yKT2ZjCM92au3ZkuodjBxOibxM67A==}
     engines: {node: '>=14.0.0'}
+
+  '@hapi/topo@5.0.0':
+    resolution: {integrity: sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==}
 
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
@@ -1922,6 +1931,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -2439,6 +2452,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-env@5.2.1:
     resolution: {integrity: sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==}
@@ -5037,6 +5051,13 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.2.0:
+    resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
+    engines: {node: '>=16.0.0'}
+
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
@@ -7551,7 +7572,7 @@ snapshots:
   '@hapi/accept@5.0.2':
     dependencies:
       '@hapi/boom': 9.1.4
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/accept@6.0.3':
     dependencies:
@@ -7560,7 +7581,7 @@ snapshots:
 
   '@hapi/ammo@5.0.1':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/ammo@6.0.1':
     dependencies:
@@ -7568,7 +7589,7 @@ snapshots:
 
   '@hapi/b64@5.0.0':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/b64@6.0.1':
     dependencies:
@@ -7580,12 +7601,12 @@ snapshots:
 
   '@hapi/boom@9.1.4':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/bounce@2.0.0':
     dependencies:
       '@hapi/boom': 9.1.4
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/bounce@3.0.2':
     dependencies:
@@ -7599,7 +7620,7 @@ snapshots:
   '@hapi/call@8.0.1':
     dependencies:
       '@hapi/boom': 9.1.4
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/call@9.0.1':
     dependencies:
@@ -7609,7 +7630,7 @@ snapshots:
   '@hapi/catbox-memory@5.0.1':
     dependencies:
       '@hapi/boom': 9.1.4
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/catbox-memory@6.0.2':
     dependencies:
@@ -7619,7 +7640,7 @@ snapshots:
   '@hapi/catbox@11.1.1':
     dependencies:
       '@hapi/boom': 9.1.4
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/podium': 4.1.3
       '@hapi/validate': 1.1.3
 
@@ -7660,7 +7681,7 @@ snapshots:
   '@hapi/h2o2@9.1.0':
     dependencies:
       '@hapi/boom': 9.1.4
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/validate': 1.1.3
       '@hapi/wreck': 17.2.0
 
@@ -7674,7 +7695,7 @@ snapshots:
       '@hapi/catbox': 11.1.1
       '@hapi/catbox-memory': 5.0.1
       '@hapi/heavy': 7.0.1
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/mimos': 6.0.0
       '@hapi/podium': 4.1.3
       '@hapi/shot': 5.0.5
@@ -7682,7 +7703,7 @@ snapshots:
       '@hapi/statehood': 7.0.4
       '@hapi/subtext': 7.1.0
       '@hapi/teamwork': 5.1.1
-      '@hapi/topo': 5.1.0
+      '@hapi/topo': 5.0.0
       '@hapi/validate': 1.1.3
 
   '@hapi/hapi@21.3.12':
@@ -7709,7 +7730,7 @@ snapshots:
   '@hapi/heavy@7.0.1':
     dependencies:
       '@hapi/boom': 9.1.4
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/validate': 1.1.3
 
   '@hapi/heavy@8.0.1':
@@ -7720,6 +7741,8 @@ snapshots:
 
   '@hapi/hoek@11.0.7': {}
 
+  '@hapi/hoek@9.1.1': {}
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/iron@6.0.0':
@@ -7728,7 +7751,7 @@ snapshots:
       '@hapi/boom': 9.1.4
       '@hapi/bourne': 2.1.0
       '@hapi/cryptiles': 5.1.0
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/iron@7.0.1':
     dependencies:
@@ -7740,7 +7763,7 @@ snapshots:
 
   '@hapi/mimos@6.0.0':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       mime-db: 1.53.0
 
   '@hapi/mimos@7.0.1':
@@ -7750,7 +7773,7 @@ snapshots:
 
   '@hapi/nigel@4.0.2':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/vise': 4.0.0
 
   '@hapi/nigel@5.0.1':
@@ -7763,7 +7786,7 @@ snapshots:
       '@hapi/b64': 5.0.0
       '@hapi/boom': 9.1.4
       '@hapi/content': 5.0.2
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/nigel': 4.0.2
 
   '@hapi/pez@6.1.0':
@@ -7776,7 +7799,7 @@ snapshots:
 
   '@hapi/podium@4.1.3':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/teamwork': 5.1.1
       '@hapi/validate': 1.1.3
 
@@ -7788,7 +7811,7 @@ snapshots:
 
   '@hapi/shot@5.0.5':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/validate': 1.1.3
 
   '@hapi/shot@6.0.1':
@@ -7799,7 +7822,7 @@ snapshots:
   '@hapi/somever@3.0.1':
     dependencies:
       '@hapi/bounce': 2.0.0
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/somever@4.1.1':
     dependencies:
@@ -7812,7 +7835,7 @@ snapshots:
       '@hapi/bounce': 2.0.0
       '@hapi/bourne': 2.1.0
       '@hapi/cryptiles': 5.1.0
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/iron': 6.0.0
       '@hapi/validate': 1.1.3
 
@@ -7832,7 +7855,7 @@ snapshots:
       '@hapi/bourne': 2.1.0
       '@hapi/content': 5.0.2
       '@hapi/file': 2.0.0
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
       '@hapi/pez': 5.1.0
       '@hapi/wreck': 17.2.0
 
@@ -7850,6 +7873,10 @@ snapshots:
 
   '@hapi/teamwork@6.0.0': {}
 
+  '@hapi/topo@5.0.0':
+    dependencies:
+      '@hapi/hoek': 9.1.1
+
   '@hapi/topo@5.1.0':
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -7860,8 +7887,8 @@ snapshots:
 
   '@hapi/validate@1.1.3':
     dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
+      '@hapi/hoek': 9.1.1
+      '@hapi/topo': 5.0.0
 
   '@hapi/validate@2.0.1':
     dependencies:
@@ -7870,7 +7897,7 @@ snapshots:
 
   '@hapi/vise@4.0.0':
     dependencies:
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/vise@5.0.1':
     dependencies:
@@ -7880,7 +7907,7 @@ snapshots:
     dependencies:
       '@hapi/boom': 9.1.4
       '@hapi/bourne': 2.1.0
-      '@hapi/hoek': 9.3.0
+      '@hapi/hoek': 9.1.1
 
   '@hapi/wreck@18.1.0':
     dependencies:
@@ -9061,6 +9088,12 @@ snapshots:
       printable-characters: 1.0.42
 
   asap@2.0.6: {}
+
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.2.0
+      tslib: 2.8.1
 
   ast-types@0.13.4:
     dependencies:
@@ -12998,6 +13031,12 @@ snapshots:
       escape-goat: 2.1.1
 
   pure-rand@6.1.0: {}
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.2.0: {}
 
   qs@6.13.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,19 +8,19 @@ importers:
 
   .:
     dependencies:
+      asn1js:
+        specifier: ^3.0.10
+        version: 3.0.10
       joi:
         specifier: 17.4.2
         version: 17.4.2
-      node-forge:
-        specifier: ^1.3.2
-        version: 1.3.2
       tslib:
         specifier: ^2.7.0
         version: 2.7.0
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
-        version: 29.7.0
+        version: 29.7.0(supports-color@8.1.1)
       '@types/node':
         specifier: ^16.11.26
         version: 16.18.124
@@ -32,10 +32,13 @@ importers:
         version: 1.0.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
+        version: 29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
       jest-environment-node:
         specifier: ^29.7.0
         version: 29.7.0
+      node-forge:
+        specifier: ^1.3.2
+        version: 1.3.2
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
@@ -66,16 +69,16 @@ importers:
         version: 5.7.3
       wrangler:
         specifier: ^3.101.0
-        version: 3.101.0(@cloudflare/workers-types@4.20250109.0)
+        version: 3.101.0(@cloudflare/workers-types@4.20250109.0)(supports-color@8.1.1)
 
   examples/firebase/functions:
     dependencies:
       firebase-admin:
         specifier: ^13.0.2
-        version: 13.0.2(encoding@0.1.13)
+        version: 13.0.2(encoding@0.1.13)(supports-color@8.1.1)
       firebase-functions:
         specifier: ^6.2.0
-        version: 6.2.0(firebase-admin@13.0.2(encoding@0.1.13))
+        version: 6.2.0(firebase-admin@13.0.2(encoding@0.1.13)(supports-color@8.1.1))(supports-color@8.1.1)
       passkit-generator:
         specifier: workspace:*
         version: link:../../..
@@ -88,10 +91,10 @@ importers:
         version: 20.17.14
       firebase-functions-test:
         specifier: ^3.4.0
-        version: 3.4.0(firebase-admin@13.0.2(encoding@0.1.13))(firebase-functions@6.2.0(firebase-admin@13.0.2(encoding@0.1.13)))(jest@29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)))
+        version: 3.4.0(firebase-admin@13.0.2(encoding@0.1.13)(supports-color@8.1.1))(firebase-functions@6.2.0(firebase-admin@13.0.2(encoding@0.1.13)(supports-color@8.1.1))(supports-color@8.1.1))(jest@29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)))
       firebase-tools:
         specifier: ^13.29.1
-        version: 13.29.1(encoding@0.1.13)
+        version: 13.29.1(encoding@0.1.13)(supports-color@8.1.1)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -100,7 +103,7 @@ importers:
     dependencies:
       express:
         specifier: ^5.0.1
-        version: 5.0.1
+        version: 5.0.1(supports-color@8.1.1)
       node-fetch:
         specifier: ^3.2.3
         version: 3.3.2
@@ -147,13 +150,13 @@ importers:
         version: 20.17.14
       serverless-offline:
         specifier: ^8.8.1
-        version: 8.8.1(encoding@0.1.13)(serverless@3.40.0(encoding@0.1.13))
+        version: 8.8.1(encoding@0.1.13)(serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13))(supports-color@8.1.1)
       serverless-plugin-typescript:
         specifier: ^2.1.5
-        version: 2.1.5(serverless@3.40.0(encoding@0.1.13))(typescript@5.7.3)
+        version: 2.1.5(serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13))(typescript@5.7.3)
       serverless-s3-local:
         specifier: ^0.8.5
-        version: 0.8.5(serverless@3.40.0(encoding@0.1.13))
+        version: 0.8.5(serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13))(supports-color@8.1.1)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -1922,6 +1925,10 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  asn1js@3.0.10:
+    resolution: {integrity: sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==}
+    engines: {node: '>=12.0.0'}
+
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
     engines: {node: '>=4'}
@@ -1952,6 +1959,7 @@ packages:
   aws-sdk@2.1692.0:
     resolution: {integrity: sha512-x511uiJ/57FIsbgUe5csJ13k3uzu25uWQE+XqfBis/sB0SFoiElJWXRkgEAUh0U6n40eT3ay5Ue4oPkRMu1LYw==}
     engines: {node: '>= 10.0.0'}
+    deprecated: The AWS SDK for JavaScript (v2) has reached end-of-support, and no longer receives updates. Please migrate your code to use AWS SDK for JavaScript (v3). More info https://a.co/cUPnyil
 
   axios@1.7.9:
     resolution: {integrity: sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==}
@@ -2003,6 +2011,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
@@ -2437,6 +2446,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-env@5.2.1:
     resolution: {integrity: sha512-1yHhtcfAd1r4nwQgknowuUNfIT9E8dOMMspC36g45dN+iD1blloi7xp8X/xAIDnjHWyt1uQ8PHk2fkNaym7soQ==}
@@ -3279,15 +3289,17 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-dirs@3.0.1:
     resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
@@ -4015,6 +4027,7 @@ packages:
 
   json-ptr@3.1.1:
     resolution: {integrity: sha512-SiSJQ805W1sDUCD1+/t1/1BIrveq2Fe9HJqENxZmMCILmrPI7WhS/pePpIOx85v6/H2z1Vy7AI08GV2TzfXocg==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   json-refs@3.0.15:
     resolution: {integrity: sha512-0vOQd9eLNBL18EGl5yYaO44GhixmImes2wiYn9Z3sag3QnehWrYWlB9AFtMxCL2Bj3fyxgDYkxGFEU/chlYssw==}
@@ -4544,6 +4557,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
@@ -5030,6 +5044,13 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  pvtsutils@1.3.6:
+    resolution: {integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==}
+
+  pvutils@1.2.0:
+    resolution: {integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==}
+    engines: {node: '>=16.0.0'}
 
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
@@ -5649,6 +5670,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tcp-port-used@1.0.2:
     resolution: {integrity: sha512-l7ar8lLUD3XS1V2lfoJlCBaeoaWo/2xfYt81hM7VlvR4RrMVFqfmzfhLVk40hAb368uitje5gPtBRL1m/DGvLA==}
@@ -5936,14 +5958,17 @@ packages:
 
   uuid@8.0.0:
     resolution: {integrity: sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -6049,6 +6074,7 @@ packages:
   wrangler@3.101.0:
     resolution: {integrity: sha512-zKRqL/jjyF54DH8YCCaF4B2x0v9kSdxLpNkxGDltZ17vCBbq9PCchooN25jbmxOTC2LWdB2LVDw7S66zdl7XuQ==}
     engines: {node: '>=16.17.0'}
+    deprecated: Downgrade to 3.99.0
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20241230.0
@@ -7016,17 +7042,17 @@ snapshots:
 
   '@babel/compat-data@7.25.8': {}
 
-  '@babel/core@7.25.8':
+  '@babel/core@7.25.8(supports-color@8.1.1)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@babel/code-frame': 7.25.7
       '@babel/generator': 7.25.7
       '@babel/helper-compilation-targets': 7.25.7
-      '@babel/helper-module-transforms': 7.25.7(@babel/core@7.25.8)
+      '@babel/helper-module-transforms': 7.25.7(@babel/core@7.25.8(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.25.7
       '@babel/parser': 7.25.8
       '@babel/template': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.25.7(supports-color@8.1.1)
       '@babel/types': 7.25.8
       convert-source-map: 2.0.0
       debug: 4.3.7(supports-color@8.1.1)
@@ -7051,28 +7077,28 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-module-imports@7.25.7':
+  '@babel/helper-module-imports@7.25.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.25.7(supports-color@8.1.1)
       '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.25.7(@babel/core@7.25.8)':
+  '@babel/helper-module-transforms@7.25.7(@babel/core@7.25.8(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.25.8
-      '@babel/helper-module-imports': 7.25.7
-      '@babel/helper-simple-access': 7.25.7
+      '@babel/core': 7.25.8(supports-color@8.1.1)
+      '@babel/helper-module-imports': 7.25.7(supports-color@8.1.1)
+      '@babel/helper-simple-access': 7.25.7(supports-color@8.1.1)
       '@babel/helper-validator-identifier': 7.25.7
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.25.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-plugin-utils@7.25.7': {}
 
-  '@babel/helper-simple-access@7.25.7':
+  '@babel/helper-simple-access@7.25.7(supports-color@8.1.1)':
     dependencies:
-      '@babel/traverse': 7.25.7
+      '@babel/traverse': 7.25.7(supports-color@8.1.1)
       '@babel/types': 7.25.8
     transitivePeerDependencies:
       - supports-color
@@ -7099,89 +7125,89 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.8
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-import-attributes@7.25.7(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-import-attributes@7.25.7(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-jsx@7.25.7(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-jsx@7.25.7(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
-  '@babel/plugin-syntax-typescript@7.25.7(@babel/core@7.25.8)':
+  '@babel/plugin-syntax-typescript@7.25.7(@babel/core@7.25.8(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.25.7
 
   '@babel/template@7.25.7':
@@ -7190,7 +7216,7 @@ snapshots:
       '@babel/parser': 7.25.8
       '@babel/types': 7.25.8
 
-  '@babel/traverse@7.25.7':
+  '@babel/traverse@7.25.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.25.7
       '@babel/generator': 7.25.7
@@ -7443,22 +7469,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@google-cloud/cloud-sql-connector@1.5.0(encoding@0.1.13)':
+  '@google-cloud/cloud-sql-connector@1.5.0(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
-      '@googleapis/sqladmin': 24.0.0(encoding@0.1.13)
-      gaxios: 6.7.1(encoding@0.1.13)
-      google-auth-library: 9.15.0(encoding@0.1.13)
+      '@googleapis/sqladmin': 24.0.0(encoding@0.1.13)(supports-color@8.1.1)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
+      google-auth-library: 9.15.0(encoding@0.1.13)(supports-color@8.1.1)
       p-throttle: 7.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@google-cloud/firestore@7.11.0(encoding@0.1.13)':
+  '@google-cloud/firestore@7.11.0(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       fast-deep-equal: 3.1.3
       functional-red-black-tree: 1.0.1
-      google-gax: 4.4.1(encoding@0.1.13)
+      google-gax: 4.4.1(encoding@0.1.13)(supports-color@8.1.1)
       protobufjs: 7.4.0
     transitivePeerDependencies:
       - encoding
@@ -7476,7 +7502,7 @@ snapshots:
 
   '@google-cloud/promisify@4.0.0': {}
 
-  '@google-cloud/pubsub@4.9.0(encoding@0.1.13)':
+  '@google-cloud/pubsub@4.9.0(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/precise-date': 4.0.0
@@ -7486,8 +7512,8 @@ snapshots:
       '@opentelemetry/semantic-conventions': 1.26.0
       arrify: 2.0.1
       extend: 3.0.2
-      google-auth-library: 9.15.0(encoding@0.1.13)
-      google-gax: 4.4.1(encoding@0.1.13)
+      google-auth-library: 9.15.0(encoding@0.1.13)(supports-color@8.1.1)
+      google-gax: 4.4.1(encoding@0.1.13)(supports-color@8.1.1)
       heap-js: 2.6.0
       is-stream-ended: 0.1.4
       lodash.snakecase: 4.1.1
@@ -7496,7 +7522,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@google-cloud/storage@7.15.0(encoding@0.1.13)':
+  '@google-cloud/storage@7.15.0(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
       '@google-cloud/paginator': 5.0.2
       '@google-cloud/projectify': 4.0.0
@@ -7505,22 +7531,22 @@ snapshots:
       async-retry: 1.3.3
       duplexify: 4.1.3
       fast-xml-parser: 4.4.1
-      gaxios: 6.7.1(encoding@0.1.13)
-      google-auth-library: 9.15.0(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
+      google-auth-library: 9.15.0(encoding@0.1.13)(supports-color@8.1.1)
       html-entities: 2.5.2
       mime: 3.0.0
       p-limit: 3.1.0
-      retry-request: 7.0.2(encoding@0.1.13)
-      teeny-request: 9.0.0(encoding@0.1.13)
+      retry-request: 7.0.2(encoding@0.1.13)(supports-color@8.1.1)
+      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@8.1.1)
       uuid: 8.3.2
     transitivePeerDependencies:
       - encoding
       - supports-color
     optional: true
 
-  '@googleapis/sqladmin@24.0.0(encoding@0.1.13)':
+  '@googleapis/sqladmin@24.0.0(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
-      googleapis-common: 7.2.0(encoding@0.1.13)
+      googleapis-common: 7.2.0(encoding@0.1.13)(supports-color@8.1.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -7905,12 +7931,12 @@ snapshots:
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))':
+  '@jest/core@29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))':
     dependencies:
       '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
+      '@jest/reporters': 29.7.0(supports-color@8.1.1)
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@types/node': 20.17.14
       ansi-escapes: 4.3.2
@@ -7919,15 +7945,15 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-resolve-dependencies: 29.7.0(supports-color@8.1.1)
+      jest-runner: 29.7.0(supports-color@8.1.1)
+      jest-runtime: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -7940,12 +7966,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))':
+  '@jest/core@29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))':
     dependencies:
       '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
+      '@jest/reporters': 29.7.0(supports-color@8.1.1)
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@types/node': 20.17.14
       ansi-escapes: 4.3.2
@@ -7954,15 +7980,15 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-resolve-dependencies: 29.7.0(supports-color@8.1.1)
+      jest-runner: 29.7.0(supports-color@8.1.1)
+      jest-runtime: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
@@ -7986,10 +8012,10 @@ snapshots:
     dependencies:
       jest-get-type: 29.6.3
 
-  '@jest/expect@29.7.0':
+  '@jest/expect@29.7.0(supports-color@8.1.1)':
     dependencies:
       expect: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8002,21 +8028,21 @@ snapshots:
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
-  '@jest/globals@29.7.0':
+  '@jest/globals@29.7.0(supports-color@8.1.1)':
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0
+      '@jest/expect': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
-  '@jest/reporters@29.7.0':
+  '@jest/reporters@29.7.0(supports-color@8.1.1)':
     dependencies:
       '@bcoe/v8-coverage': 0.2.3
       '@jest/console': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       '@types/node': 20.17.14
@@ -8026,9 +8052,9 @@ snapshots:
       glob: 7.2.3
       graceful-fs: 4.2.11
       istanbul-lib-coverage: 3.2.2
-      istanbul-lib-instrument: 6.0.3
+      istanbul-lib-instrument: 6.0.3(supports-color@8.1.1)
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 4.0.1
+      istanbul-lib-source-maps: 4.0.1(supports-color@8.1.1)
       istanbul-reports: 3.1.7
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -8064,12 +8090,12 @@ snapshots:
       jest-haste-map: 29.7.0
       slash: 3.0.0
 
-  '@jest/transform@29.7.0':
+  '@jest/transform@29.7.0(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      babel-plugin-istanbul: 6.1.1
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
       chalk: 4.1.2
       convert-source-map: 2.0.0
       fast-json-stable-stringify: 2.1.0
@@ -8127,7 +8153,7 @@ snapshots:
     dependencies:
       jsep: 1.4.0
 
-  '@koa/router@9.4.0':
+  '@koa/router@9.4.0(supports-color@8.1.1)':
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
       http-errors: 1.8.1
@@ -8157,13 +8183,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.18.0
 
-  '@npmcli/agent@2.2.2':
+  '@npmcli/agent@2.2.2(supports-color@8.1.1)':
     dependencies:
       agent-base: 7.1.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 10.4.3
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -8215,12 +8241,12 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@serverless/dashboard-plugin@7.2.3(encoding@0.1.13)(supports-color@8.1.1)':
+  '@serverless/dashboard-plugin@7.2.3(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:
       '@aws-sdk/client-cloudformation': 3.726.1
       '@aws-sdk/client-sts': 3.726.1
       '@serverless/event-mocks': 1.1.1
-      '@serverless/platform-client': 4.5.1(supports-color@8.1.1)
+      '@serverless/platform-client': 4.5.1(debug@4.3.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@serverless/utils': 6.15.0(encoding@0.1.13)
       child-process-ext: 3.0.2
       chokidar: 3.6.0
@@ -8253,11 +8279,11 @@ snapshots:
       '@types/lodash': 4.17.14
       lodash: 4.17.21
 
-  '@serverless/platform-client@4.5.1(supports-color@8.1.1)':
+  '@serverless/platform-client@4.5.1(debug@4.3.7(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       adm-zip: 0.5.16
       archiver: 5.3.2
-      axios: 1.7.9
+      axios: 1.7.9(debug@4.3.7(supports-color@8.1.1))
       fast-glob: 3.3.3
       https-proxy-agent: 5.0.1(supports-color@8.1.1)
       ignore: 5.3.2
@@ -9051,6 +9077,12 @@ snapshots:
 
   asap@2.0.6: {}
 
+  asn1js@3.0.10:
+    dependencies:
+      pvtsutils: 1.3.6
+      pvutils: 1.2.0
+      tslib: 2.8.1
+
   ast-types@0.13.4:
     dependencies:
       tslib: 2.8.1
@@ -9089,9 +9121,9 @@ snapshots:
       uuid: 8.0.0
       xml2js: 0.6.2
 
-  axios@1.7.9:
+  axios@1.7.9(debug@4.3.7(supports-color@8.1.1)):
     dependencies:
-      follow-redirects: 1.15.9
+      follow-redirects: 1.15.9(debug@4.3.7(supports-color@8.1.1))
       form-data: 4.0.1
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -9099,25 +9131,25 @@ snapshots:
 
   b4a@1.6.7: {}
 
-  babel-jest@29.7.0(@babel/core@7.25.8):
+  babel-jest@29.7.0(@babel/core@7.25.8(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.25.8
-      '@jest/transform': 29.7.0
+      '@babel/core': 7.25.8(supports-color@8.1.1)
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.25.8)
+      babel-plugin-istanbul: 6.1.1(supports-color@8.1.1)
+      babel-preset-jest: 29.6.3(@babel/core@7.25.8(supports-color@8.1.1))
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-istanbul@6.1.1:
+  babel-plugin-istanbul@6.1.1(supports-color@8.1.1):
     dependencies:
       '@babel/helper-plugin-utils': 7.25.7
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
-      istanbul-lib-instrument: 5.2.1
+      istanbul-lib-instrument: 5.2.1(supports-color@8.1.1)
       test-exclude: 6.0.0
     transitivePeerDependencies:
       - supports-color
@@ -9129,30 +9161,30 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
-  babel-preset-current-node-syntax@1.1.0(@babel/core@7.25.8):
+  babel-preset-current-node-syntax@1.1.0(@babel/core@7.25.8(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.25.8
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.8)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.25.8)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.8)
-      '@babel/plugin-syntax-import-attributes': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.8)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.8)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.8)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.8)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.8)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.25.8)
+      '@babel/core': 7.25.8(supports-color@8.1.1)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-attributes': 7.25.7(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.25.8(supports-color@8.1.1))
 
-  babel-preset-jest@29.6.3(@babel/core@7.25.8):
+  babel-preset-jest@29.6.3(@babel/core@7.25.8(supports-color@8.1.1)):
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.25.8)
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.25.8(supports-color@8.1.1))
 
   balanced-match@1.0.2: {}
 
@@ -9190,11 +9222,11 @@ snapshots:
 
   bluebird@3.7.2: {}
 
-  body-parser@1.20.3:
+  body-parser@1.20.3(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.0
@@ -9207,11 +9239,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  body-parser@2.0.2:
+  body-parser@2.0.2(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 3.1.0
+      debug: 3.1.0(supports-color@8.1.1)
       destroy: 1.2.0
       http-errors: 2.0.0
       iconv-lite: 0.5.2
@@ -9377,7 +9409,7 @@ snapshots:
 
   caniuse-lite@1.0.30001668: {}
 
-  capnp-ts@0.7.0:
+  capnp-ts@0.7.0(supports-color@8.1.1):
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
       tslib: 2.8.1
@@ -9590,11 +9622,11 @@ snapshots:
     dependencies:
       mime-db: 1.53.0
 
-  compression@1.7.5:
+  compression@1.7.5(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       negotiator: 0.6.4
       on-headers: 1.0.2
       safe-buffer: 5.2.1
@@ -9620,10 +9652,10 @@ snapshots:
       write-file-atomic: 3.0.3
       xdg-basedir: 4.0.0
 
-  connect@3.7.0:
+  connect@3.7.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
-      finalhandler: 1.1.2
+      debug: 2.6.9(supports-color@8.1.1)
+      finalhandler: 1.1.2(supports-color@8.1.1)
       parseurl: 1.3.3
       utils-merge: 1.0.1
     transitivePeerDependencies:
@@ -9675,13 +9707,13 @@ snapshots:
       crc-32: 1.2.2
       readable-stream: 4.7.0
 
-  create-jest@29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
+  create-jest@29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -9690,13 +9722,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)):
+  create-jest@29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -9769,25 +9801,35 @@ snapshots:
 
   dayjs@1.11.13: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@3.1.0:
+  debug@3.1.0(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@3.2.7:
+  debug@3.2.7(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.3.1:
+  debug@4.3.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.3.6:
+  debug@4.3.6(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
+      supports-color: 8.1.1
 
   debug@4.3.7(supports-color@8.1.1):
     dependencies:
@@ -10243,18 +10285,18 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
-  exegesis-express@4.0.0:
+  exegesis-express@4.0.0(supports-color@8.1.1):
     dependencies:
-      exegesis: 4.2.0
+      exegesis: 4.2.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  exegesis@4.2.0:
+  exegesis@4.2.0(supports-color@8.1.1):
     dependencies:
       '@apidevtools/json-schema-ref-parser': 9.1.2
       ajv: 8.17.1
       ajv-formats: 2.1.1(ajv@8.17.1)
-      body-parser: 1.20.3
+      body-parser: 1.20.3(supports-color@8.1.1)
       content-type: 1.0.5
       deep-freeze: 0.0.1
       events-listener: 1.1.0
@@ -10286,21 +10328,21 @@ snapshots:
   exponential-backoff@3.1.1:
     optional: true
 
-  express@4.21.2:
+  express@4.21.2(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.3(supports-color@8.1.1)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.0.6
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.1
+      finalhandler: 1.3.1(supports-color@8.1.1)
       fresh: 0.5.2
       http-errors: 2.0.0
       merge-descriptors: 1.0.3
@@ -10312,8 +10354,8 @@ snapshots:
       qs: 6.13.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.2
+      send: 0.19.0(supports-color@8.1.1)
+      serve-static: 1.16.2(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -10322,20 +10364,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  express@5.0.1:
+  express@5.0.1(supports-color@8.1.1):
     dependencies:
       accepts: 2.0.0
-      body-parser: 2.0.2
+      body-parser: 2.0.2(supports-color@8.1.1)
       content-disposition: 1.0.0
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.2.2
-      debug: 4.3.6
+      debug: 4.3.6(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 2.0.0
+      finalhandler: 2.0.0(supports-color@8.1.1)
       fresh: 2.0.0
       http-errors: 2.0.0
       merge-descriptors: 2.0.0
@@ -10349,8 +10391,8 @@ snapshots:
       range-parser: 1.2.1
       router: 2.0.0
       safe-buffer: 5.2.1
-      send: 1.1.0
-      serve-static: 2.1.0
+      send: 1.1.0(supports-color@8.1.1)
+      serve-static: 2.1.0(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 2.0.0
@@ -10471,9 +10513,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.1.2:
+  finalhandler@1.1.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.3.0
@@ -10483,9 +10525,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@1.3.1:
+  finalhandler@1.3.1(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -10495,9 +10537,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  finalhandler@2.0.0:
+  finalhandler@2.0.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 1.0.2
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -10517,55 +10559,55 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
-  firebase-admin@13.0.2(encoding@0.1.13):
+  firebase-admin@13.0.2(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       '@fastify/busboy': 3.1.1
       '@firebase/database-compat': 2.0.1
       '@firebase/database-types': 1.0.7
       '@types/node': 22.10.5
       farmhash-modern: 1.1.0
-      google-auth-library: 9.15.0(encoding@0.1.13)
+      google-auth-library: 9.15.0(encoding@0.1.13)(supports-color@8.1.1)
       jsonwebtoken: 9.0.2
-      jwks-rsa: 3.1.0
+      jwks-rsa: 3.1.0(supports-color@8.1.1)
       node-forge: 1.3.2
       uuid: 11.0.5
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.0(encoding@0.1.13)
-      '@google-cloud/storage': 7.15.0(encoding@0.1.13)
+      '@google-cloud/firestore': 7.11.0(encoding@0.1.13)(supports-color@8.1.1)
+      '@google-cloud/storage': 7.15.0(encoding@0.1.13)(supports-color@8.1.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  firebase-functions-test@3.4.0(firebase-admin@13.0.2(encoding@0.1.13))(firebase-functions@6.2.0(firebase-admin@13.0.2(encoding@0.1.13)))(jest@29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))):
+  firebase-functions-test@3.4.0(firebase-admin@13.0.2(encoding@0.1.13)(supports-color@8.1.1))(firebase-functions@6.2.0(firebase-admin@13.0.2(encoding@0.1.13)(supports-color@8.1.1))(supports-color@8.1.1))(jest@29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))):
     dependencies:
       '@types/lodash': 4.17.14
-      firebase-admin: 13.0.2(encoding@0.1.13)
-      firebase-functions: 6.2.0(firebase-admin@13.0.2(encoding@0.1.13))
-      jest: 29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
+      firebase-admin: 13.0.2(encoding@0.1.13)(supports-color@8.1.1)
+      firebase-functions: 6.2.0(firebase-admin@13.0.2(encoding@0.1.13)(supports-color@8.1.1))(supports-color@8.1.1)
+      jest: 29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
       lodash: 4.17.21
       ts-deepmerge: 2.0.7
 
-  firebase-functions@6.2.0(firebase-admin@13.0.2(encoding@0.1.13)):
+  firebase-functions@6.2.0(firebase-admin@13.0.2(encoding@0.1.13)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@types/cors': 2.8.17
       '@types/express': 4.17.21
       cors: 2.8.5
-      express: 4.21.2
-      firebase-admin: 13.0.2(encoding@0.1.13)
+      express: 4.21.2(supports-color@8.1.1)
+      firebase-admin: 13.0.2(encoding@0.1.13)(supports-color@8.1.1)
       protobufjs: 7.4.0
     transitivePeerDependencies:
       - supports-color
 
-  firebase-tools@13.29.1(encoding@0.1.13):
+  firebase-tools@13.29.1(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       '@electric-sql/pglite': 0.2.15
-      '@google-cloud/cloud-sql-connector': 1.5.0(encoding@0.1.13)
-      '@google-cloud/pubsub': 4.9.0(encoding@0.1.13)
+      '@google-cloud/cloud-sql-connector': 1.5.0(encoding@0.1.13)(supports-color@8.1.1)
+      '@google-cloud/pubsub': 4.9.0(encoding@0.1.13)(supports-color@8.1.1)
       abort-controller: 3.0.0
       ajv: 6.12.6
       archiver: 7.0.1
       async-lock: 1.4.1
-      body-parser: 1.20.3
+      body-parser: 1.20.3(supports-color@8.1.1)
       chokidar: 3.6.0
       cjson: 0.3.3
       cli-table: 0.3.11
@@ -10577,16 +10619,16 @@ snapshots:
       cross-spawn: 7.0.3
       csv-parse: 5.6.0
       deep-equal-in-any-order: 2.0.6
-      exegesis: 4.2.0
-      exegesis-express: 4.0.0
-      express: 4.21.2
+      exegesis: 4.2.0(supports-color@8.1.1)
+      exegesis-express: 4.0.0(supports-color@8.1.1)
+      express: 4.21.2(supports-color@8.1.1)
       filesize: 6.4.0
       form-data: 4.0.1
       fs-extra: 10.1.0
       fuzzy: 0.1.3
-      gaxios: 6.7.1(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
       glob: 10.4.5
-      google-auth-library: 9.15.0(encoding@0.1.13)
+      google-auth-library: 9.15.0(encoding@0.1.13)(supports-color@8.1.1)
       inquirer: 8.2.6
       inquirer-autocomplete-prompt: 2.0.1(inquirer@8.2.6)
       js-yaml: 3.14.1
@@ -10599,26 +10641,26 @@ snapshots:
       marked-terminal: 7.2.1(marked@13.0.3)
       mime: 2.6.0
       minimatch: 3.1.2
-      morgan: 1.10.0
+      morgan: 1.10.0(supports-color@8.1.1)
       node-fetch: 2.7.0(encoding@0.1.13)
       open: 6.4.0
       ora: 5.4.1
       p-limit: 3.1.0
       pg: 8.13.1
-      portfinder: 1.0.32
+      portfinder: 1.0.32(supports-color@8.1.1)
       progress: 2.0.3
-      proxy-agent: 6.5.0
+      proxy-agent: 6.5.0(supports-color@8.1.1)
       retry: 0.13.1
       semver: 7.6.3
       sql-formatter: 15.4.9
       stream-chain: 2.2.5
       stream-json: 1.9.1
-      superstatic: 9.1.0(encoding@0.1.13)
+      superstatic: 9.1.0(encoding@0.1.13)(supports-color@8.1.1)
       tar: 6.2.1
-      tcp-port-used: 1.0.2
+      tcp-port-used: 1.0.2(supports-color@8.1.1)
       tmp: 0.2.3
       triple-beam: 1.4.1
-      universal-analytics: 0.5.3
+      universal-analytics: 0.5.3(supports-color@8.1.1)
       update-notifier-cjs: 5.1.6(encoding@0.1.13)
       uuid: 8.3.2
       winston: 3.17.0
@@ -10636,7 +10678,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.9: {}
+  follow-redirects@1.15.9(debug@4.3.7(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.3.7(supports-color@8.1.1)
 
   for-each@0.3.3:
     dependencies:
@@ -10753,10 +10797,10 @@ snapshots:
 
   fuzzy@0.1.3: {}
 
-  gaxios@6.7.1(encoding@0.1.13):
+  gaxios@6.7.1(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       extend: 3.0.2
-      https-proxy-agent: 7.0.6
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       is-stream: 2.0.1
       node-fetch: 2.7.0(encoding@0.1.13)
       uuid: 9.0.1
@@ -10764,9 +10808,9 @@ snapshots:
       - encoding
       - supports-color
 
-  gcp-metadata@6.1.0(encoding@0.1.13):
+  gcp-metadata@6.1.0(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
@@ -10826,7 +10870,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.4:
+  get-uri@6.0.4(supports-color@8.1.1):
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
@@ -10904,41 +10948,41 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  google-auth-library@9.15.0(encoding@0.1.13):
+  google-auth-library@9.15.0(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
-      gaxios: 6.7.1(encoding@0.1.13)
-      gcp-metadata: 6.1.0(encoding@0.1.13)
-      gtoken: 7.1.0(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
+      gcp-metadata: 6.1.0(encoding@0.1.13)(supports-color@8.1.1)
+      gtoken: 7.1.0(encoding@0.1.13)(supports-color@8.1.1)
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  google-gax@4.4.1(encoding@0.1.13):
+  google-gax@4.4.1(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       '@grpc/grpc-js': 1.12.5
       '@grpc/proto-loader': 0.7.13
       '@types/long': 4.0.2
       abort-controller: 3.0.0
       duplexify: 4.1.3
-      google-auth-library: 9.15.0(encoding@0.1.13)
+      google-auth-library: 9.15.0(encoding@0.1.13)(supports-color@8.1.1)
       node-fetch: 2.7.0(encoding@0.1.13)
       object-hash: 3.0.0
       proto3-json-serializer: 2.0.2
       protobufjs: 7.4.0
-      retry-request: 7.0.2(encoding@0.1.13)
+      retry-request: 7.0.2(encoding@0.1.13)(supports-color@8.1.1)
       uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  googleapis-common@7.2.0(encoding@0.1.13):
+  googleapis-common@7.2.0(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       extend: 3.0.2
-      gaxios: 6.7.1(encoding@0.1.13)
-      google-auth-library: 9.15.0(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
+      google-auth-library: 9.15.0(encoding@0.1.13)(supports-color@8.1.1)
       qs: 6.13.1
       url-template: 2.0.8
       uuid: 9.0.1
@@ -10970,9 +11014,9 @@ snapshots:
     dependencies:
       lodash: 4.17.21
 
-  gtoken@7.1.0(encoding@0.1.13):
+  gtoken@7.1.0(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
-      gaxios: 6.7.1(encoding@0.1.13)
+      gaxios: 6.7.1(encoding@0.1.13)(supports-color@8.1.1)
       jws: 4.0.0
     transitivePeerDependencies:
       - encoding
@@ -11042,7 +11086,7 @@ snapshots:
 
   http-parser-js@0.5.9: {}
 
-  http-proxy-agent@5.0.0:
+  http-proxy-agent@5.0.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2(supports-color@8.1.1)
@@ -11050,7 +11094,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy-agent@7.0.2:
+  http-proxy-agent@7.0.2(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.3.7(supports-color@8.1.1)
@@ -11069,7 +11113,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  https-proxy-agent@7.0.6:
+  https-proxy-agent@7.0.6(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.3.7(supports-color@8.1.1)
@@ -11391,9 +11435,9 @@ snapshots:
 
   istanbul-lib-coverage@3.2.2: {}
 
-  istanbul-lib-instrument@5.2.1:
+  istanbul-lib-instrument@5.2.1(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/parser': 7.25.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -11401,9 +11445,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  istanbul-lib-instrument@6.0.3:
+  istanbul-lib-instrument@6.0.3(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/parser': 7.25.8
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -11417,7 +11461,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@4.0.1:
+  istanbul-lib-source-maps@4.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
@@ -11446,10 +11490,10 @@ snapshots:
       jest-util: 29.7.0
       p-limit: 3.1.0
 
-  jest-circus@29.7.0:
+  jest-circus@29.7.0(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 29.7.0
-      '@jest/expect': 29.7.0
+      '@jest/expect': 29.7.0(supports-color@8.1.1)
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.17.14
@@ -11460,8 +11504,8 @@ snapshots:
       jest-each: 29.7.0
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-runtime: 29.7.0(supports-color@8.1.1)
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       p-limit: 3.1.0
       pretty-format: 29.7.0
@@ -11472,16 +11516,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
+  jest-cli@29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
+      '@jest/core': 29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
+      create-jest: 29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -11491,16 +11535,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)):
+  jest-cli@29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
+      '@jest/core': 29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
+      create-jest: 29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -11510,23 +11554,23 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
+  jest-config@29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.25.8)
+      babel-jest: 29.7.0(@babel/core@7.25.8(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(supports-color@8.1.1)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0
+      jest-runner: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -11541,23 +11585,23 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
+  jest-config@29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.25.8)
+      babel-jest: 29.7.0(@babel/core@7.25.8(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(supports-color@8.1.1)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0
+      jest-runner: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -11572,23 +11616,23 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)):
+  jest-config@29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)):
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.25.8)
+      babel-jest: 29.7.0(@babel/core@7.25.8(supports-color@8.1.1))(supports-color@8.1.1)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
       glob: 7.2.3
       graceful-fs: 4.2.11
-      jest-circus: 29.7.0
+      jest-circus: 29.7.0(supports-color@8.1.1)
       jest-environment-node: 29.7.0
       jest-get-type: 29.6.3
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-runner: 29.7.0
+      jest-runner: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       micromatch: 4.0.8
@@ -11685,10 +11729,10 @@ snapshots:
 
   jest-regex-util@29.6.3: {}
 
-  jest-resolve-dependencies@29.7.0:
+  jest-resolve-dependencies@29.7.0(supports-color@8.1.1):
     dependencies:
       jest-regex-util: 29.6.3
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -11704,12 +11748,12 @@ snapshots:
       resolve.exports: 2.0.2
       slash: 3.0.0
 
-  jest-runner@29.7.0:
+  jest-runner@29.7.0(supports-color@8.1.1):
     dependencies:
       '@jest/console': 29.7.0
       '@jest/environment': 29.7.0
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@types/node': 20.17.14
       chalk: 4.1.2
@@ -11721,7 +11765,7 @@ snapshots:
       jest-leak-detector: 29.7.0
       jest-message-util: 29.7.0
       jest-resolve: 29.7.0
-      jest-runtime: 29.7.0
+      jest-runtime: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       jest-watcher: 29.7.0
       jest-worker: 29.7.0
@@ -11730,14 +11774,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jest-runtime@29.7.0:
+  jest-runtime@29.7.0(supports-color@8.1.1):
     dependencies:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
-      '@jest/globals': 29.7.0
+      '@jest/globals': 29.7.0(supports-color@8.1.1)
       '@jest/source-map': 29.6.3
       '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
       '@types/node': 20.17.14
       chalk: 4.1.2
@@ -11750,24 +11794,24 @@ snapshots:
       jest-mock: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
-      jest-snapshot: 29.7.0
+      jest-snapshot: 29.7.0(supports-color@8.1.1)
       jest-util: 29.7.0
       slash: 3.0.0
       strip-bom: 4.0.0
     transitivePeerDependencies:
       - supports-color
 
-  jest-snapshot@29.7.0:
+  jest-snapshot@29.7.0(supports-color@8.1.1):
     dependencies:
-      '@babel/core': 7.25.8
+      '@babel/core': 7.25.8(supports-color@8.1.1)
       '@babel/generator': 7.25.7
-      '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.8)
-      '@babel/plugin-syntax-typescript': 7.25.7(@babel/core@7.25.8)
+      '@babel/plugin-syntax-jsx': 7.25.7(@babel/core@7.25.8(supports-color@8.1.1))
+      '@babel/plugin-syntax-typescript': 7.25.7(@babel/core@7.25.8(supports-color@8.1.1))
       '@babel/types': 7.25.8
       '@jest/expect-utils': 29.7.0
-      '@jest/transform': 29.7.0
+      '@jest/transform': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.25.8)
+      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.25.8(supports-color@8.1.1))
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -11818,24 +11862,24 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
+  jest@29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
+      '@jest/core': 29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
+      jest-cli: 29.7.0(@types/node@16.18.124)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)):
+  jest@29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
+      '@jest/core': 29.7.0(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.17.14)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
+      jest-cli: 29.7.0(@types/node@20.17.14)(supports-color@8.1.1)(ts-node@10.9.2(@types/node@20.17.14)(typescript@5.7.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -11988,7 +12032,7 @@ snapshots:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
-  jwks-rsa@3.1.0:
+  jwks-rsa@3.1.0(supports-color@8.1.1):
     dependencies:
       '@types/express': 4.17.21
       '@types/jsonwebtoken': 9.0.7
@@ -12041,7 +12085,7 @@ snapshots:
       humanize-number: 0.0.2
       passthrough-counter: 1.0.0
 
-  koa@2.15.3:
+  koa@2.15.3(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       cache-content-type: 1.0.1
@@ -12226,9 +12270,9 @@ snapshots:
   make-error@1.3.6:
     optional: true
 
-  make-fetch-happen@13.0.1:
+  make-fetch-happen@13.0.1(supports-color@8.1.1):
     dependencies:
-      '@npmcli/agent': 2.2.2
+      '@npmcli/agent': 2.2.2(supports-color@8.1.1)
       cacache: 18.0.4
       http-cache-semantics: 4.1.1
       is-lambda: 1.0.1
@@ -12325,12 +12369,12 @@ snapshots:
 
   mimic-response@3.1.0: {}
 
-  miniflare@3.20241230.1:
+  miniflare@3.20241230.1(supports-color@8.1.1):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       acorn: 8.14.0
       acorn-walk: 8.3.4
-      capnp-ts: 0.7.0
+      capnp-ts: 0.7.0(supports-color@8.1.1)
       exit-hook: 2.2.1
       glob-to-regexp: 0.4.1
       stoppable: 1.1.0
@@ -12425,10 +12469,10 @@ snapshots:
 
   moo@0.5.2: {}
 
-  morgan@1.10.0:
+  morgan@1.10.0(supports-color@8.1.1):
     dependencies:
       basic-auth: 2.0.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       on-finished: 2.3.0
       on-headers: 1.0.2
@@ -12517,13 +12561,13 @@ snapshots:
 
   node-forge@1.3.2: {}
 
-  node-gyp@10.3.1:
+  node-gyp@10.3.1(supports-color@8.1.1):
     dependencies:
       env-paths: 2.2.1
       exponential-backoff: 3.1.1
       glob: 10.4.5
       graceful-fs: 4.2.11
-      make-fetch-happen: 13.0.1
+      make-fetch-happen: 13.0.1(supports-color@8.1.1)
       nopt: 7.2.1
       proc-log: 4.2.0
       semver: 7.6.3
@@ -12723,16 +12767,16 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  pac-proxy-agent@7.1.0:
+  pac-proxy-agent@7.1.0(supports-color@8.1.1):
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
       debug: 4.3.7(supports-color@8.1.1)
-      get-uri: 6.0.4
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      get-uri: 6.0.4(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12869,10 +12913,10 @@ snapshots:
       mlly: 1.7.3
       pathe: 1.1.2
 
-  portfinder@1.0.32:
+  portfinder@1.0.32(supports-color@8.1.1):
     dependencies:
       async: 2.6.4
-      debug: 3.2.7
+      debug: 3.2.7(supports-color@8.1.1)
       mkdirp: 0.5.6
     transitivePeerDependencies:
       - supports-color
@@ -12956,16 +13000,16 @@ snapshots:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
 
-  proxy-agent@6.5.0:
+  proxy-agent@6.5.0(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.3.7(supports-color@8.1.1)
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
+      http-proxy-agent: 7.0.2(supports-color@8.1.1)
+      https-proxy-agent: 7.0.6(supports-color@8.1.1)
       lru-cache: 7.18.3
-      pac-proxy-agent: 7.1.0
+      pac-proxy-agent: 7.1.0(supports-color@8.1.1)
       proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
+      socks-proxy-agent: 8.0.5(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -12987,6 +13031,12 @@ snapshots:
       escape-goat: 2.1.1
 
   pure-rand@6.1.0: {}
+
+  pvtsutils@1.3.6:
+    dependencies:
+      tslib: 2.8.1
+
+  pvutils@1.2.0: {}
 
   qs@6.13.0:
     dependencies:
@@ -13036,11 +13086,11 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  re2@1.21.4:
+  re2@1.21.4(supports-color@8.1.1):
     dependencies:
       install-artifact-from-github: 1.3.5
       nan: 2.22.0
-      node-gyp: 10.3.1
+      node-gyp: 10.3.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -13154,11 +13204,11 @@ snapshots:
 
   ret@0.1.15: {}
 
-  retry-request@7.0.2(encoding@0.1.13):
+  retry-request@7.0.2(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       '@types/request': 2.48.12
       extend: 3.0.2
-      teeny-request: 9.0.0(encoding@0.1.13)
+      teeny-request: 9.0.0(encoding@0.1.13)(supports-color@8.1.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13218,15 +13268,15 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  s3rver@3.7.1:
+  s3rver@3.7.1(supports-color@8.1.1):
     dependencies:
-      '@koa/router': 9.4.0
+      '@koa/router': 9.4.0(supports-color@8.1.1)
       busboy: 0.3.1
       commander: 5.1.0
       fast-xml-parser: 3.21.1
       fs-extra: 8.1.0
       he: 1.2.0
-      koa: 2.15.3
+      koa: 2.15.3(supports-color@8.1.1)
       koa-logger: 3.2.1
       lodash: 4.17.21
       statuses: 2.0.1
@@ -13282,9 +13332,9 @@ snapshots:
 
   semver@7.6.3: {}
 
-  send@0.19.0:
+  send@0.19.0(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -13300,7 +13350,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  send@1.1.0:
+  send@1.1.0(supports-color@8.1.1):
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
       destroy: 1.2.0
@@ -13317,25 +13367,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.2:
+  serve-static@1.16.2(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0
+      send: 0.19.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@2.1.0:
+  serve-static@2.1.0(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 1.1.0
+      send: 1.1.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  serverless-offline@13.9.0(serverless@3.40.0(encoding@0.1.13)):
+  serverless-offline@13.9.0(serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13))(supports-color@8.1.1):
     dependencies:
       '@aws-sdk/client-lambda': 3.726.1
       '@hapi/boom': 10.0.1
@@ -13357,8 +13407,8 @@ snapshots:
       luxon: 3.5.0
       node-schedule: 2.1.1
       p-memoize: 7.1.1
-      serverless: 3.40.0(encoding@0.1.13)
-      velocityjs: 2.0.6
+      serverless: 3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13)
+      velocityjs: 2.0.6(supports-color@8.1.1)
       ws: 8.18.0
     transitivePeerDependencies:
       - aws-crt
@@ -13366,7 +13416,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  serverless-offline@8.8.1(encoding@0.1.13)(serverless@3.40.0(encoding@0.1.13)):
+  serverless-offline@8.8.1(encoding@0.1.13)(serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13))(supports-color@8.1.1):
     dependencies:
       '@hapi/boom': 9.1.4
       '@hapi/h2o2': 9.1.0
@@ -13390,8 +13440,8 @@ snapshots:
       p-queue: 6.6.2
       p-retry: 4.6.2
       semver: 7.6.3
-      serverless: 3.40.0(encoding@0.1.13)
-      velocityjs: 2.0.6
+      serverless: 3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13)
+      velocityjs: 2.0.6(supports-color@8.1.1)
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -13399,22 +13449,22 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  serverless-plugin-typescript@2.1.5(serverless@3.40.0(encoding@0.1.13))(typescript@5.7.3):
+  serverless-plugin-typescript@2.1.5(serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13))(typescript@5.7.3):
     dependencies:
       fs-extra: 7.0.1
       globby: 10.0.2
       lodash: 4.17.21
-      serverless: 3.40.0(encoding@0.1.13)
+      serverless: 3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13)
       typescript: 5.7.3
 
-  serverless-s3-local@0.8.5(serverless@3.40.0(encoding@0.1.13)):
+  serverless-s3-local@0.8.5(serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13))(supports-color@8.1.1):
     dependencies:
       '@aws-sdk/client-s3': 3.726.1
       fs-extra: 11.2.0
       rxjs: 6.6.7
       rxjs-compat: 6.6.7
-      s3rver: 3.7.1
-      serverless-offline: 13.9.0(serverless@3.40.0(encoding@0.1.13))
+      s3rver: 3.7.1(supports-color@8.1.1)
+      serverless-offline: 13.9.0(serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13))(supports-color@8.1.1)
       shelljs: 0.8.5
     transitivePeerDependencies:
       - aws-crt
@@ -13423,7 +13473,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  serverless@3.40.0(encoding@0.1.13):
+  serverless@3.40.0(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13):
     dependencies:
       '@aws-sdk/client-api-gateway': 3.726.1
       '@aws-sdk/client-cognito-identity-provider': 3.726.1
@@ -13431,8 +13481,8 @@ snapshots:
       '@aws-sdk/client-iam': 3.726.1
       '@aws-sdk/client-lambda': 3.726.1
       '@aws-sdk/client-s3': 3.726.1
-      '@serverless/dashboard-plugin': 7.2.3(encoding@0.1.13)(supports-color@8.1.1)
-      '@serverless/platform-client': 4.5.1(supports-color@8.1.1)
+      '@serverless/dashboard-plugin': 7.2.3(debug@4.3.7(supports-color@8.1.1))(encoding@0.1.13)(supports-color@8.1.1)
+      '@serverless/platform-client': 4.5.1(debug@4.3.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@serverless/utils': 6.15.0(encoding@0.1.13)
       abort-controller: 3.0.0
       ajv: 8.17.1
@@ -13592,7 +13642,7 @@ snapshots:
 
   smart-buffer@4.2.0: {}
 
-  socks-proxy-agent@8.0.5:
+  socks-proxy-agent@8.0.5(supports-color@8.1.1):
     dependencies:
       agent-base: 7.1.3
       debug: 4.3.7(supports-color@8.1.1)
@@ -13799,12 +13849,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  superstatic@9.1.0(encoding@0.1.13):
+  superstatic@9.1.0(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
       basic-auth-connect: 1.1.0
       commander: 10.0.1
-      compression: 1.7.5
-      connect: 3.7.0
+      compression: 1.7.5(supports-color@8.1.1)
+      connect: 3.7.0(supports-color@8.1.1)
       destroy: 1.2.0
       fast-url-parser: 1.1.3
       glob-slasher: 1.0.1
@@ -13813,14 +13863,14 @@ snapshots:
       lodash: 4.17.21
       mime-types: 2.1.35
       minimatch: 6.2.0
-      morgan: 1.10.0
+      morgan: 1.10.0(supports-color@8.1.1)
       on-finished: 2.4.1
       on-headers: 1.0.2
       path-to-regexp: 1.9.0
       router: 2.0.0
       update-notifier-cjs: 5.1.6(encoding@0.1.13)
     optionalDependencies:
-      re2: 1.21.4
+      re2: 1.21.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13881,16 +13931,16 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
-  tcp-port-used@1.0.2:
+  tcp-port-used@1.0.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.3.1
+      debug: 4.3.1(supports-color@8.1.1)
       is2: 2.0.9
     transitivePeerDependencies:
       - supports-color
 
-  teeny-request@9.0.0(encoding@0.1.13):
+  teeny-request@9.0.0(encoding@0.1.13)(supports-color@8.1.1):
     dependencies:
-      http-proxy-agent: 5.0.0
+      http-proxy-agent: 5.0.0(supports-color@8.1.1)
       https-proxy-agent: 5.0.1(supports-color@8.1.1)
       node-fetch: 2.7.0(encoding@0.1.13)
       stream-events: 1.0.5
@@ -14157,7 +14207,7 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
-  universal-analytics@0.5.3:
+  universal-analytics@0.5.3(supports-color@8.1.1):
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
       uuid: 8.3.2
@@ -14249,7 +14299,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  velocityjs@2.0.6:
+  velocityjs@2.0.6(supports-color@8.1.1):
     dependencies:
       debug: 4.3.7(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -14371,7 +14421,7 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20241230.0
       '@cloudflare/workerd-windows-64': 1.20241230.0
 
-  wrangler@3.101.0(@cloudflare/workers-types@4.20250109.0):
+  wrangler@3.101.0(@cloudflare/workers-types@4.20250109.0)(supports-color@8.1.1):
     dependencies:
       '@aws-sdk/client-s3': 3.726.1
       '@cloudflare/kv-asset-handler': 0.3.4
@@ -14382,7 +14432,7 @@ snapshots:
       date-fns: 4.1.0
       esbuild: 0.17.19
       itty-time: 1.0.6
-      miniflare: 3.20241230.1
+      miniflare: 3.20241230.1(supports-color@8.1.1)
       nanoid: 3.3.8
       path-to-regexp: 6.3.0
       resolve: 1.22.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      do-not-zip:
-        specifier: ^1.0.0
-        version: 1.0.0
       joi:
         specifier: 17.4.2
         version: 17.4.2
@@ -24,15 +21,15 @@ importers:
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
-      '@types/do-not-zip':
-        specifier: ^1.0.2
-        version: 1.0.2
       '@types/node':
         specifier: ^16.11.26
         version: 16.18.124
       '@types/node-forge':
         specifier: ^1.3.11
         version: 1.3.11
+      do-not-zip:
+        specifier: ^1.0.0
+        version: 1.0.0
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@16.18.124)(ts-node@10.9.2(@types/node@16.18.124)(typescript@5.7.3))
@@ -1654,9 +1651,6 @@ packages:
 
   '@types/cors@2.8.17':
     resolution: {integrity: sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==}
-
-  '@types/do-not-zip@1.0.2':
-    resolution: {integrity: sha512-J978lrQQD67I42aI/r1NusHmeQbBbf00WK05/r8p6Tbh7mTmWqgU0fjf8ZQ30jRgzBGYmJR/wuL9IhRU5h2mMA==}
 
   '@types/express-serve-static-core@4.19.6':
     resolution: {integrity: sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==}
@@ -8735,10 +8729,6 @@ snapshots:
       '@types/node': 20.17.14
 
   '@types/cors@2.8.17':
-    dependencies:
-      '@types/node': 20.17.14
-
-  '@types/do-not-zip@1.0.2':
     dependencies:
       '@types/node': 20.17.14
 

--- a/specs/Signature.spec.mjs
+++ b/specs/Signature.spec.mjs
@@ -1,0 +1,300 @@
+// @ts-check
+/**
+ * Correctness bar for the signing path.
+ *
+ * A pass signature is checked by real devices, so every assertion here is made
+ * against something other than the code that produced it: an independent
+ * ASN.1 walk plus node:crypto, and — where the binary exists — openssl itself.
+ */
+
+import { expect, it, describe, beforeAll } from "@jest/globals";
+import { execFileSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Buffer } from "node:buffer";
+import { PKPass } from "passkit-generator";
+import { readZipEntries } from "./zipReader.mjs";
+import { verifyDetachedSignature } from "./verifySignature.mjs";
+import { generateCertificates, createAssets, PASS_PROPS } from "./fixtures.mjs";
+
+const assets = createAssets();
+
+/**
+ * Passphrases are generated per run rather than written into the file.
+ * Nothing in the signing path depends on a particular value, and a string
+ * literal that looks like a password trips secret scanners for no reason.
+ */
+function testPassphrase() {
+	return randomBytes(16).toString("hex");
+}
+
+const hasOpenssl = (() => {
+	try {
+		execFileSync("openssl", ["version"], { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+})();
+
+/**
+ * @param {import("passkit-generator").PassProps extends never ? never : any} certificates
+ */
+function buildPass(certificates, overrides = {}) {
+	const pass = new PKPass({}, certificates, { ...PASS_PROPS, ...overrides });
+
+	for (const [fileName, buffer] of Object.entries(assets)) {
+		pass.addBuffer(fileName, buffer);
+	}
+
+	pass.type = "storeCard";
+
+	return readZipEntries(pass.getAsBuffer());
+}
+
+/**
+ * Runs `openssl smime -verify` over a detached signature, returning stderr
+ * on failure instead of throwing, so both outcomes can be asserted.
+ */
+function opensslVerify(signature, content, { caFile } = {}) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pkpass-verify-"));
+
+	try {
+		const signaturePath = path.join(dir, "signature");
+		const contentPath = path.join(dir, "content");
+
+		fs.writeFileSync(signaturePath, signature);
+		fs.writeFileSync(contentPath, content);
+
+		const args = [
+			"smime",
+			"-verify",
+			"-inform",
+			"DER",
+			"-in",
+			signaturePath,
+			"-content",
+			contentPath,
+		];
+
+		if (caFile) {
+			const caPath = path.join(dir, "ca.pem");
+			fs.writeFileSync(caPath, caFile);
+			args.push("-CAfile", caPath, "-purpose", "any");
+		} else {
+			args.push("-noverify");
+		}
+
+		try {
+			execFileSync("openssl", args, { stdio: "pipe" });
+			return { ok: true, stderr: "" };
+		} catch (error) {
+			return { ok: false, stderr: String(error.stderr ?? error) };
+		}
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe("Signature", () => {
+	describe("with an unencrypted PKCS#1 signer key", () => {
+		const certificates = generateCertificates();
+		/** @type {{[k: string]: Buffer}} */
+		let files;
+
+		beforeAll(() => {
+			files = buildPass(certificates);
+		});
+
+		it("produces a signature an independent verifier accepts", () => {
+			const result = verifyDetachedSignature(
+				files["signature"],
+				files["manifest.json"],
+				certificates.signerCert,
+			);
+
+			expect(result.certificateCount).toBe(2);
+			expect(result.digestAlgorithmCount).toBe(1);
+			expect(result.signingTime).toBeTruthy();
+		});
+
+		it("rejects a tampered manifest", () => {
+			expect(() =>
+				verifyDetachedSignature(
+					files["signature"],
+					Buffer.from(
+						'{"icon.png":"0000000000000000000000000000000000000000"}',
+					),
+					certificates.signerCert,
+				),
+			).toThrow(/messageDigest/);
+		});
+
+		it("does not verify against an unrelated certificate", () => {
+			const stranger = generateCertificates();
+
+			expect(() =>
+				verifyDetachedSignature(
+					files["signature"],
+					files["manifest.json"],
+					stranger.signerCert,
+				),
+			).toThrow(/RSA verification/);
+		});
+
+		(hasOpenssl ? it : it.skip)("verifies under openssl smime", () => {
+			expect(
+				opensslVerify(files["signature"], files["manifest.json"]),
+			).toMatchObject({ ok: true });
+		});
+
+		(hasOpenssl ? it : it.skip)(
+			"verifies its certificate chain up to the WWDR certificate",
+			() => {
+				expect(
+					opensslVerify(files["signature"], files["manifest.json"], {
+						caFile: certificates.wwdr,
+					}),
+				).toMatchObject({ ok: true });
+			},
+		);
+
+		(hasOpenssl ? it : it.skip)(
+			"is rejected by openssl when the manifest is tampered with",
+			() => {
+				expect(
+					opensslVerify(files["signature"], Buffer.from("tampered")),
+				).toMatchObject({ ok: false });
+			},
+		);
+	});
+
+	describe("with an encrypted PKCS#8 signer key", () => {
+		it("accepts a passphrase-protected key carrying a Bag Attributes preamble", () => {
+			const certificates = generateCertificates({
+				passphrase: testPassphrase(),
+				bagAttributes: true,
+			});
+
+			expect(certificates.signerKey.toString("utf-8")).toMatch(
+				/^Bag Attributes/,
+			);
+
+			const files = buildPass(certificates);
+
+			expect(() =>
+				verifyDetachedSignature(
+					files["signature"],
+					files["manifest.json"],
+					certificates.signerCert,
+				),
+			).not.toThrow();
+		});
+
+		it("fails loudly when the passphrase is wrong", () => {
+			const correct = testPassphrase();
+			const certificates = generateCertificates({
+				passphrase: correct,
+				bagAttributes: true,
+			});
+
+			expect(() =>
+				buildPass({
+					...certificates,
+					signerKeyPassphrase: `${correct}-not-it`,
+				}),
+			).toThrow();
+		});
+
+		it("fails loudly when the passphrase is missing entirely", () => {
+			const certificates = generateCertificates({
+				passphrase: testPassphrase(),
+			});
+
+			expect(() =>
+				buildPass({ ...certificates, signerKeyPassphrase: undefined }),
+			).toThrow();
+		});
+	});
+
+	describe("signer key caching", () => {
+		it("signs correctly across repeated passes with the same key", () => {
+			const certificates = generateCertificates({
+				passphrase: testPassphrase(),
+			});
+
+			for (let i = 0; i < 3; i++) {
+				const files = buildPass(certificates, {
+					serialNumber: `repeat-${i}`,
+				});
+
+				expect(() =>
+					verifyDetachedSignature(
+						files["signature"],
+						files["manifest.json"],
+						certificates.signerCert,
+					),
+				).not.toThrow();
+			}
+		});
+
+		it("keeps distinct keys apart when they are interleaved", () => {
+			const first = generateCertificates({
+				passphrase: testPassphrase(),
+			});
+			const second = generateCertificates({
+				passphrase: testPassphrase(),
+			});
+
+			for (const [a, b] of [
+				[first, second],
+				[second, first],
+			]) {
+				const filesA = buildPass(a);
+				const filesB = buildPass(b);
+
+				/** Each signature must verify against its own certificate... */
+				expect(() =>
+					verifyDetachedSignature(
+						filesA["signature"],
+						filesA["manifest.json"],
+						a.signerCert,
+					),
+				).not.toThrow();
+
+				/** ...and must not verify against the other's */
+				expect(() =>
+					verifyDetachedSignature(
+						filesA["signature"],
+						filesA["manifest.json"],
+						b.signerCert,
+					),
+				).toThrow(/RSA verification/);
+
+				expect(() =>
+					verifyDetachedSignature(
+						filesB["signature"],
+						filesB["manifest.json"],
+						b.signerCert,
+					),
+				).not.toThrow();
+			}
+		});
+
+		it("does not let the same key with a different passphrase collide", () => {
+			const correct = testPassphrase();
+			const certificates = generateCertificates({ passphrase: correct });
+
+			expect(() => buildPass(certificates)).not.toThrow();
+			expect(() =>
+				buildPass({
+					...certificates,
+					signerKeyPassphrase: `${correct}-not-it`,
+				}),
+			).toThrow();
+			expect(() => buildPass(certificates)).not.toThrow();
+		});
+	});
+});

--- a/specs/Signature.spec.mjs
+++ b/specs/Signature.spec.mjs
@@ -1,0 +1,281 @@
+// @ts-check
+/**
+ * Correctness bar for the signing path.
+ *
+ * A pass signature is checked by real devices, so every assertion here is made
+ * against something other than the code that produced it: an independent
+ * ASN.1 walk plus node:crypto, and — where the binary exists — openssl itself.
+ */
+
+import { expect, it, describe, beforeAll } from "@jest/globals";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Buffer } from "node:buffer";
+import { PKPass } from "passkit-generator";
+import { readZipEntries } from "./zipReader.mjs";
+import { verifyDetachedSignature } from "./verifySignature.mjs";
+import { generateCertificates, createAssets, PASS_PROPS } from "./fixtures.mjs";
+
+const assets = createAssets();
+
+const hasOpenssl = (() => {
+	try {
+		execFileSync("openssl", ["version"], { stdio: "ignore" });
+		return true;
+	} catch {
+		return false;
+	}
+})();
+
+/**
+ * @param {import("passkit-generator").PassProps extends never ? never : any} certificates
+ */
+function buildPass(certificates, overrides = {}) {
+	const pass = new PKPass({}, certificates, { ...PASS_PROPS, ...overrides });
+
+	for (const [fileName, buffer] of Object.entries(assets)) {
+		pass.addBuffer(fileName, buffer);
+	}
+
+	pass.type = "storeCard";
+
+	return readZipEntries(pass.getAsBuffer());
+}
+
+/**
+ * Runs `openssl smime -verify` over a detached signature, returning stderr
+ * on failure instead of throwing, so both outcomes can be asserted.
+ */
+function opensslVerify(signature, content, { caFile } = {}) {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), "pkpass-verify-"));
+
+	try {
+		const signaturePath = path.join(dir, "signature");
+		const contentPath = path.join(dir, "content");
+
+		fs.writeFileSync(signaturePath, signature);
+		fs.writeFileSync(contentPath, content);
+
+		const args = [
+			"smime",
+			"-verify",
+			"-inform",
+			"DER",
+			"-in",
+			signaturePath,
+			"-content",
+			contentPath,
+		];
+
+		if (caFile) {
+			const caPath = path.join(dir, "ca.pem");
+			fs.writeFileSync(caPath, caFile);
+			args.push("-CAfile", caPath, "-purpose", "any");
+		} else {
+			args.push("-noverify");
+		}
+
+		try {
+			execFileSync("openssl", args, { stdio: "pipe" });
+			return { ok: true, stderr: "" };
+		} catch (error) {
+			return { ok: false, stderr: String(error.stderr ?? error) };
+		}
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+describe("Signature", () => {
+	describe("with an unencrypted PKCS#1 signer key", () => {
+		const certificates = generateCertificates();
+		/** @type {{[k: string]: Buffer}} */
+		let files;
+
+		beforeAll(() => {
+			files = buildPass(certificates);
+		});
+
+		it("produces a signature an independent verifier accepts", () => {
+			const result = verifyDetachedSignature(
+				files["signature"],
+				files["manifest.json"],
+				certificates.signerCert,
+			);
+
+			expect(result.certificateCount).toBe(2);
+			expect(result.digestAlgorithmCount).toBe(1);
+			expect(result.signingTime).toBeTruthy();
+		});
+
+		it("rejects a tampered manifest", () => {
+			expect(() =>
+				verifyDetachedSignature(
+					files["signature"],
+					Buffer.from(
+						'{"icon.png":"0000000000000000000000000000000000000000"}',
+					),
+					certificates.signerCert,
+				),
+			).toThrow(/messageDigest/);
+		});
+
+		it("does not verify against an unrelated certificate", () => {
+			const stranger = generateCertificates();
+
+			expect(() =>
+				verifyDetachedSignature(
+					files["signature"],
+					files["manifest.json"],
+					stranger.signerCert,
+				),
+			).toThrow(/RSA verification/);
+		});
+
+		(hasOpenssl ? it : it.skip)("verifies under openssl smime", () => {
+			expect(
+				opensslVerify(files["signature"], files["manifest.json"]),
+			).toMatchObject({ ok: true });
+		});
+
+		(hasOpenssl ? it : it.skip)(
+			"verifies its certificate chain up to the WWDR certificate",
+			() => {
+				expect(
+					opensslVerify(files["signature"], files["manifest.json"], {
+						caFile: certificates.wwdr,
+					}),
+				).toMatchObject({ ok: true });
+			},
+		);
+
+		(hasOpenssl ? it : it.skip)(
+			"is rejected by openssl when the manifest is tampered with",
+			() => {
+				expect(
+					opensslVerify(files["signature"], Buffer.from("tampered")),
+				).toMatchObject({ ok: false });
+			},
+		);
+	});
+
+	describe("with an encrypted PKCS#8 signer key", () => {
+		it("accepts a passphrase-protected key carrying a Bag Attributes preamble", () => {
+			const certificates = generateCertificates({
+				passphrase: "a-real-passphrase",
+				bagAttributes: true,
+			});
+
+			expect(certificates.signerKey.toString("utf-8")).toMatch(
+				/^Bag Attributes/,
+			);
+
+			const files = buildPass(certificates);
+
+			expect(() =>
+				verifyDetachedSignature(
+					files["signature"],
+					files["manifest.json"],
+					certificates.signerCert,
+				),
+			).not.toThrow();
+		});
+
+		it("fails loudly when the passphrase is wrong", () => {
+			const certificates = generateCertificates({
+				passphrase: "the-right-one",
+				bagAttributes: true,
+			});
+
+			expect(() =>
+				buildPass({
+					...certificates,
+					signerKeyPassphrase: "the-wrong-one",
+				}),
+			).toThrow();
+		});
+
+		it("fails loudly when the passphrase is missing entirely", () => {
+			const certificates = generateCertificates({
+				passphrase: "the-right-one",
+			});
+
+			expect(() =>
+				buildPass({ ...certificates, signerKeyPassphrase: undefined }),
+			).toThrow();
+		});
+	});
+
+	describe("signer key caching", () => {
+		it("signs correctly across repeated passes with the same key", () => {
+			const certificates = generateCertificates({
+				passphrase: "repeated",
+			});
+
+			for (let i = 0; i < 3; i++) {
+				const files = buildPass(certificates, {
+					serialNumber: `repeat-${i}`,
+				});
+
+				expect(() =>
+					verifyDetachedSignature(
+						files["signature"],
+						files["manifest.json"],
+						certificates.signerCert,
+					),
+				).not.toThrow();
+			}
+		});
+
+		it("keeps distinct keys apart when they are interleaved", () => {
+			const first = generateCertificates({ passphrase: "first" });
+			const second = generateCertificates({ passphrase: "second" });
+
+			for (const [a, b] of [
+				[first, second],
+				[second, first],
+			]) {
+				const filesA = buildPass(a);
+				const filesB = buildPass(b);
+
+				/** Each signature must verify against its own certificate... */
+				expect(() =>
+					verifyDetachedSignature(
+						filesA["signature"],
+						filesA["manifest.json"],
+						a.signerCert,
+					),
+				).not.toThrow();
+
+				/** ...and must not verify against the other's */
+				expect(() =>
+					verifyDetachedSignature(
+						filesA["signature"],
+						filesA["manifest.json"],
+						b.signerCert,
+					),
+				).toThrow(/RSA verification/);
+
+				expect(() =>
+					verifyDetachedSignature(
+						filesB["signature"],
+						filesB["manifest.json"],
+						b.signerCert,
+					),
+				).not.toThrow();
+			}
+		});
+
+		it("does not let the same key with a different passphrase collide", () => {
+			const certificates = generateCertificates({ passphrase: "right" });
+
+			expect(() => buildPass(certificates)).not.toThrow();
+			expect(() =>
+				buildPass({ ...certificates, signerKeyPassphrase: "wrong" }),
+			).toThrow();
+			expect(() => buildPass(certificates)).not.toThrow();
+		});
+	});
+});

--- a/specs/Zip.spec.mjs
+++ b/specs/Zip.spec.mjs
@@ -1,0 +1,175 @@
+// @ts-check
+/**
+ * The zip writer replaced `do-not-zip`, whose output shipped in every pass
+ * issued by previous versions. These tests pin the replacement to that exact
+ * byte layout, including the cases PKPass itself cannot reach, and check the
+ * result against an independent reader.
+ */
+
+import { expect, it, describe } from "@jest/globals";
+import { Buffer } from "node:buffer";
+import crypto from "node:crypto";
+import { toArray as doNotZip } from "do-not-zip";
+import { createZip } from "../lib/esm/Zip.js";
+import { readZip, crc32 } from "./zipReader.mjs";
+import { createAssets } from "./fixtures.mjs";
+
+/**
+ * @type {[string, {path: string, data: Buffer}[]][]}
+ */
+const CASES = [
+	["an empty archive", []],
+	["a single empty file", [{ path: "empty.txt", data: Buffer.alloc(0) }]],
+	[
+		"an empty file between two non-empty ones",
+		[
+			{ path: "a.txt", data: Buffer.from("A") },
+			{ path: "b.txt", data: Buffer.alloc(0) },
+			{ path: "c.txt", data: Buffer.from("CCC") },
+		],
+	],
+	[
+		"nested localization paths",
+		[
+			{
+				path: "en.lproj/pass.strings",
+				data: Buffer.from('"K" = "V";\n'),
+			},
+			{
+				path: "it.lproj/pass.strings",
+				data: Buffer.from('"K" = "W";\n'),
+			},
+		],
+	],
+	[
+		"a file name longer than 255 bytes",
+		[{ path: `${"x".repeat(300)}.png`, data: Buffer.from("data") }],
+	],
+	[
+		"a payload larger than a megabyte",
+		[{ path: "big.bin", data: crypto.randomBytes(1024 * 1024) }],
+	],
+	[
+		"many small files",
+		Array.from({ length: 200 }, (_, i) => ({
+			path: `f${i}.txt`,
+			data: Buffer.from(`payload-${i}`),
+		})),
+	],
+	[
+		"a realistic pass bundle",
+		Object.entries(createAssets()).map(([path, data]) => ({ path, data })),
+	],
+];
+
+describe("Zip", () => {
+	describe("byte compatibility with do-not-zip", () => {
+		it.each(CASES)("matches do-not-zip for %s", (_label, entries) => {
+			expect(createZip(entries).toString("base64")).toBe(
+				Buffer.from(doNotZip(entries)).toString("base64"),
+			);
+		});
+	});
+
+	describe("structure", () => {
+		it("stores entries uncompressed, in the order given", () => {
+			const entries = Object.entries(createAssets()).map(
+				([path, data]) => ({ path, data }),
+			);
+
+			const { entries: read } = readZip(createZip(entries));
+
+			expect(read.map((e) => e.name)).toEqual(entries.map((e) => e.path));
+
+			for (let i = 0; i < entries.length; i++) {
+				expect(read[i].data.equals(entries[i].data)).toBe(true);
+			}
+		});
+
+		it("records a correct CRC-32 for every entry", () => {
+			const entries = [
+				{ path: "a.bin", data: crypto.randomBytes(1000) },
+				{ path: "b.bin", data: Buffer.alloc(0) },
+				{ path: "c.bin", data: crypto.randomBytes(70000) },
+			];
+
+			for (const entry of readZip(createZip(entries)).entries) {
+				const source = entries.find((e) => e.path === entry.name);
+				expect(entry.crc).toBe(crc32(source.data));
+			}
+		});
+
+		it("points each central directory record at its local header", () => {
+			const entries = Array.from({ length: 12 }, (_, i) => ({
+				path: `f${i}.bin`,
+				data: crypto.randomBytes(100 * (i + 1)),
+			}));
+
+			const archive = createZip(entries);
+			const { entries: read, eocd } = readZip(archive);
+
+			expect(eocd.entryCount).toBe(entries.length);
+
+			/** readZip already cross-checks names and CRCs at each offset */
+			for (const entry of read) {
+				expect(archive.readUInt32LE(entry.offset)).toBe(0x04034b50);
+			}
+		});
+
+		it("describes an empty archive with a bare end-of-central-directory record", () => {
+			const archive = createZip([]);
+
+			expect(archive.length).toBe(22);
+			expect(readZip(archive).eocd).toEqual({
+				entryCount: 0,
+				centralDirectorySize: 0,
+				centralDirectoryOffset: 0,
+			});
+		});
+	});
+
+	describe("scaling", () => {
+		/**
+		 * The implementation this replaced rebuilt the whole archive once per
+		 * file, in a plain array of numbers, so cost grew with the square of the
+		 * bundle size.
+		 *
+		 * Both writers are timed here on the same input, back to back, so the
+		 * comparison calibrates itself against whatever else the machine happens
+		 * to be doing. The observed margin on a 2MB bundle is several hundred
+		 * times; the threshold is set far below that so this catches a
+		 * regression to quadratic behaviour without being sensitive to load.
+		 */
+
+		it("assembles a large bundle far faster than do-not-zip did", () => {
+			const entries = Array.from({ length: 32 }, (_, i) => ({
+				path: `f${i}.bin`,
+				data: crypto.randomBytes(64 * 1024),
+			}));
+
+			/** Best-of-N: the minimum is far less noisy than the mean */
+			const best = (run) => {
+				for (let i = 0; i < 2; i++) run();
+
+				let fastest = Infinity;
+
+				for (let i = 0; i < 5; i++) {
+					const start = process.hrtime.bigint();
+					run();
+					const elapsed = Number(process.hrtime.bigint() - start);
+
+					if (elapsed < fastest) {
+						fastest = elapsed;
+					}
+				}
+
+				return fastest;
+			};
+
+			const ours = best(() => createZip(entries));
+			const previous = best(() => Buffer.from(doNotZip(entries)));
+
+			expect(previous / ours).toBeGreaterThan(10);
+		});
+	});
+});

--- a/specs/fixtures.mjs
+++ b/specs/fixtures.mjs
@@ -1,0 +1,214 @@
+// @ts-check
+/**
+ * Shared fixtures for the specs.
+ *
+ * Everything here is ephemeral and generated in-process: no real signing
+ * certificate ever touches this repository.
+ */
+
+import forge from "node-forge";
+import zlib from "node:zlib";
+import { Buffer } from "node:buffer";
+
+/**
+ * Builds a self-signed CA (stands in for Apple WWDR) and a leaf signer
+ * certificate issued by it, mirroring the real trust chain shape.
+ *
+ * @param {object} [options]
+ * @param {string} [options.passphrase] when set, the signer key is emitted as
+ * 		an encrypted PKCS#8 blob instead of a plain PKCS#1 one.
+ * @param {boolean} [options.bagAttributes] prepend the `Bag Attributes`
+ * 		preamble that `openssl pkcs12` writes in front of the PEM block.
+ */
+export function generateCertificates({
+	passphrase = undefined,
+	bagAttributes = false,
+} = {}) {
+	const caKeys = forge.pki.rsa.generateKeyPair(2048);
+	const wwdr = forge.pki.createCertificate();
+
+	wwdr.publicKey = caKeys.publicKey;
+	wwdr.serialNumber = "01";
+	wwdr.validity.notBefore = new Date(2020, 0, 1);
+	wwdr.validity.notAfter = new Date(2040, 0, 1);
+
+	const caAttrs = [
+		{ name: "commonName", value: "Test WWDR CA" },
+		{ name: "organizationName", value: "passkit-generator specs" },
+	];
+
+	wwdr.setSubject(caAttrs);
+	wwdr.setIssuer(caAttrs);
+	wwdr.setExtensions([{ name: "basicConstraints", cA: true }]);
+	wwdr.sign(caKeys.privateKey, forge.md.sha256.create());
+
+	const signerKeys = forge.pki.rsa.generateKeyPair(2048);
+	const signerCert = forge.pki.createCertificate();
+
+	signerCert.publicKey = signerKeys.publicKey;
+	signerCert.serialNumber = "02";
+	signerCert.validity.notBefore = new Date(2020, 0, 1);
+	signerCert.validity.notAfter = new Date(2040, 0, 1);
+
+	signerCert.setSubject([
+		{ name: "commonName", value: "Pass Type ID: pass.com.example.test" },
+		{ name: "organizationName", value: "passkit-generator specs" },
+	]);
+	signerCert.setIssuer(caAttrs);
+	signerCert.sign(caKeys.privateKey, forge.md.sha256.create());
+
+	let signerKeyPem;
+
+	if (passphrase) {
+		signerKeyPem = forge.pki.encryptedPrivateKeyToPem(
+			forge.pki.encryptPrivateKeyInfo(
+				forge.pki.wrapRsaPrivateKey(
+					forge.pki.privateKeyToAsn1(signerKeys.privateKey),
+				),
+				passphrase,
+				{ algorithm: "aes256" },
+			),
+		);
+	} else {
+		signerKeyPem = forge.pki.privateKeyToPem(signerKeys.privateKey);
+	}
+
+	if (bagAttributes) {
+		signerKeyPem =
+			[
+				"Bag Attributes",
+				"    localKeyID: A1 B2 C3 D4 E5 F6 07 18 29 3A 4B 5C 6D 7E 8F 90",
+				"    friendlyName: Pass Type ID: pass.com.example.test",
+				"Key Attributes: <No Attributes>",
+			].join("\n") +
+			"\n" +
+			signerKeyPem;
+	}
+
+	return {
+		wwdr: Buffer.from(forge.pki.certificateToPem(wwdr)),
+		signerCert: Buffer.from(forge.pki.certificateToPem(signerCert)),
+		signerKey: Buffer.from(signerKeyPem),
+		...(passphrase ? { signerKeyPassphrase: passphrase } : {}),
+	};
+}
+
+/**
+ * Emits a structurally valid PNG of the requested pixel size. Content is
+ * deterministic, so digests over these assets are stable across runs.
+ *
+ * @param {number} width
+ * @param {number} height
+ * @param {number} seed
+ */
+export function createPng(width, height, seed = 0) {
+	const raw = Buffer.alloc(height * (1 + width * 4));
+
+	for (let y = 0; y < height; y++) {
+		const rowStart = y * (1 + width * 4);
+		raw[rowStart] = 0; // filter type: none
+
+		for (let x = 0; x < width; x++) {
+			const p = rowStart + 1 + x * 4;
+			/**
+			 * Smooth, banded gradients: real pass artwork is mostly flat
+			 * colour and compresses well, so high-entropy noise here would
+			 * inflate the fixture far past a realistic bundle size.
+			 */
+			raw[p] = ((x >> 2) + (y >> 3) + seed) & 0xff;
+			raw[p + 1] = ((x >> 3) + (y >> 2) * 2 + seed * 3) & 0xff;
+			raw[p + 2] = ((x * 3 + y) >> 3) & 0xff;
+			raw[p + 3] = 0xff;
+		}
+	}
+
+	const ihdr = Buffer.alloc(13);
+	ihdr.writeUInt32BE(width, 0);
+	ihdr.writeUInt32BE(height, 4);
+	ihdr[8] = 8; // bit depth
+	ihdr[9] = 6; // colour type: RGBA
+	ihdr[10] = 0;
+	ihdr[11] = 0;
+	ihdr[12] = 0;
+
+	return Buffer.concat([
+		Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+		pngChunk("IHDR", ihdr),
+		pngChunk("IDAT", zlib.deflateSync(raw, { level: 6 })),
+		pngChunk("IEND", Buffer.alloc(0)),
+	]);
+}
+
+function pngChunk(type, data) {
+	const out = Buffer.alloc(12 + data.length);
+	out.writeUInt32BE(data.length, 0);
+	out.write(type, 4, "ascii");
+	data.copy(out, 8);
+	out.writeUInt32BE(
+		crc32(out.subarray(4, 8 + data.length)) >>> 0,
+		8 + data.length,
+	);
+	return out;
+}
+
+const CRC_TABLE = (() => {
+	const table = new Int32Array(256);
+	for (let n = 0; n < 256; n++) {
+		let c = n;
+		for (let k = 0; k < 8; k++) {
+			c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+		}
+		table[n] = c;
+	}
+	return table;
+})();
+
+function crc32(buffer) {
+	let sum = -1;
+	for (let i = 0; i < buffer.length; i++) {
+		sum = (sum >>> 8) ^ CRC_TABLE[(sum ^ buffer[i]) & 0xff];
+	}
+	return sum ^ -1;
+}
+
+/**
+ * A realistic 10-file asset bundle weighing roughly 450KB, the shape of a
+ * real pass: three icon sizes, three logo sizes, three strip sizes and a
+ * thumbnail.
+ */
+export function createAssets() {
+	/** @type {[string, number, number][]} */
+	const spec = [
+		["icon.png", 29, 29],
+		["icon@2x.png", 58, 58],
+		["icon@3x.png", 87, 87],
+		["logo.png", 160, 50],
+		["logo@2x.png", 320, 100],
+		["logo@3x.png", 480, 150],
+		["strip.png", 375, 123],
+		["strip@2x.png", 750, 246],
+		["strip@3x.png", 1125, 369],
+		["thumbnail.png", 90, 90],
+	];
+
+	/** @type {{[fileName: string]: Buffer}} */
+	const assets = {};
+
+	spec.forEach(([name, w, h], index) => {
+		assets[name] = createPng(w, h, index);
+	});
+
+	return assets;
+}
+
+export const PASS_PROPS = Object.freeze({
+	formatVersion: 1,
+	passTypeIdentifier: "pass.com.example.test",
+	teamIdentifier: "ABCDE12345",
+	organizationName: "passkit-generator specs",
+	description: "Test pass",
+	serialNumber: "test-0001",
+	foregroundColor: "rgb(255, 255, 255)",
+	backgroundColor: "rgb(0, 122, 255)",
+	labelColor: "rgb(255, 255, 255)",
+});

--- a/specs/output.spec.mjs
+++ b/specs/output.spec.mjs
@@ -1,0 +1,206 @@
+// @ts-check
+/**
+ * Pins the shape of what a pass export actually produces.
+ *
+ * The digests and file ordering below were captured from an unmodified
+ * passkit-generator@3.5.7 running these same fixtures, before any of the
+ * performance work landed. Hashing, archiving and signing were all rewritten
+ * afterwards; none of that was allowed to change a byte of the output, and
+ * these constants are what holds that line.
+ *
+ * The manifest is a SHA-1 of every other file, so pinning it pins the exact
+ * bytes of pass.json and of each pass.strings too, not merely their presence.
+ */
+
+import { expect, it, describe, beforeAll } from "@jest/globals";
+import { Buffer } from "node:buffer";
+import { Stream } from "node:stream";
+import { PKPass } from "passkit-generator";
+import { readZip, readZipEntries } from "./zipReader.mjs";
+import { generateCertificates, createAssets, PASS_PROPS } from "./fixtures.mjs";
+
+/** Captured from passkit-generator@3.5.7 */
+const EXPECTED_FILE_ORDER = [
+	"icon.png",
+	"icon@2x.png",
+	"icon@3x.png",
+	"logo.png",
+	"logo@2x.png",
+	"logo@3x.png",
+	"strip.png",
+	"strip@2x.png",
+	"strip@3x.png",
+	"thumbnail.png",
+	"pass.json",
+	"it.lproj/pass.strings",
+	"en.lproj/pass.strings",
+	"manifest.json",
+	"signature",
+];
+
+/** Captured from passkit-generator@3.5.7 */
+const EXPECTED_MANIFEST = {
+	"icon.png": "e6d6b9ca14a27205ff706e29b0bf0693e735b861",
+	"icon@2x.png": "a4bd920cec90bd531e8f80f3e021f292ad3055a6",
+	"icon@3x.png": "69741b3e0e40533a76661fb644c0b6cb0b0b0934",
+	"logo.png": "629ae1a98d44c82b6651fb40b6298eff92858f5f",
+	"logo@2x.png": "dc377bedf65f2562ee0e3e1609880bf6472738b6",
+	"logo@3x.png": "a3fc394a385847650ba4bd8967be68292f83a688",
+	"strip.png": "07af98c463dff36a0aaffcd98bcfdcf46610ee13",
+	"strip@2x.png": "94b844b1284aaa82bd8d222eb833d1d300756968",
+	"strip@3x.png": "63fdfebbc434b425c9b070cb83a2539f4c090c30",
+	"thumbnail.png": "4c35485eaadbd5c96b08b02b05520d76dc5a5293",
+	"pass.json": "1262a57bf104dcdf6c5e94a12c47ad8316029eea",
+	"it.lproj/pass.strings": "a91fcfdc5aaf62168ae494989e302449272280bd",
+	"en.lproj/pass.strings": "e1e68d3120734ad269da0c6a371551a99cc23632",
+};
+
+const certificates = generateCertificates();
+const assets = createAssets();
+
+function buildPass() {
+	const pass = new PKPass({}, certificates, { ...PASS_PROPS });
+
+	for (const [fileName, buffer] of Object.entries(assets)) {
+		pass.addBuffer(fileName, buffer);
+	}
+
+	pass.type = "storeCard";
+	pass.primaryFields.push({
+		key: "balance",
+		label: "BALANCE",
+		value: "$42.00",
+	});
+	pass.secondaryFields.push({
+		key: "member",
+		label: "MEMBER",
+		value: "Jane Doe",
+	});
+
+	pass.localize("en", { BALANCE: "Balance", MEMBER: "Member" });
+	pass.localize("it", { BALANCE: "Saldo", MEMBER: "Membro" });
+
+	return pass;
+}
+
+describe("pass output", () => {
+	/** @type {Buffer} */
+	let bundle;
+	/** @type {{[k: string]: Buffer}} */
+	let files;
+
+	beforeAll(() => {
+		bundle = buildPass().getAsBuffer();
+		files = readZipEntries(bundle);
+	});
+
+	it("contains the same files, in the same order, as 3.5.7 produced", () => {
+		expect(readZip(bundle).entries.map((entry) => entry.name)).toEqual(
+			EXPECTED_FILE_ORDER,
+		);
+	});
+
+	it("hashes every asset to the digest 3.5.7 recorded", () => {
+		expect(JSON.parse(files["manifest.json"].toString("utf-8"))).toEqual(
+			EXPECTED_MANIFEST,
+		);
+	});
+
+	it("writes the manifest with its keys in insertion order", () => {
+		/**
+		 * The manifest is hashed and signed as raw bytes, so key order is part
+		 * of the output, not an implementation detail.
+		 */
+		expect(
+			Object.keys(JSON.parse(files["manifest.json"].toString("utf-8"))),
+		).toEqual(Object.keys(EXPECTED_MANIFEST));
+	});
+
+	it("excludes the manifest and the signature from the manifest", () => {
+		const manifest = JSON.parse(files["manifest.json"].toString("utf-8"));
+
+		expect(manifest["manifest.json"]).toBeUndefined();
+		expect(manifest["signature"]).toBeUndefined();
+	});
+
+	it("keeps pass.json keys in the documented order", () => {
+		const passJson = JSON.parse(files["pass.json"].toString("utf-8"));
+
+		expect(Object.keys(passJson)).toEqual([
+			"formatVersion",
+			"passTypeIdentifier",
+			"teamIdentifier",
+			"organizationName",
+			"description",
+			"serialNumber",
+			"foregroundColor",
+			"backgroundColor",
+			"labelColor",
+			"storeCard",
+		]);
+	});
+
+	it("writes pass.strings for every localization", () => {
+		expect(files["en.lproj/pass.strings"].toString("utf-8")).toBe(
+			'"BALANCE" = "Balance";\n"MEMBER" = "Member";',
+		);
+		expect(files["it.lproj/pass.strings"].toString("utf-8")).toBe(
+			'"BALANCE" = "Saldo";\n"MEMBER" = "Membro";',
+		);
+	});
+
+	it("emits a signature", () => {
+		expect(files["signature"].length).toBeGreaterThan(0);
+	});
+});
+
+describe("export methods", () => {
+	it("returns a Buffer synchronously, not a Promise", () => {
+		/**
+		 * The signing path is deliberately synchronous. Returning a Promise
+		 * here would break every existing caller, so it is asserted rather
+		 * than assumed.
+		 */
+
+		const result = buildPass().getAsBuffer();
+
+		expect(result).toBeInstanceOf(Buffer);
+		expect(result).not.toBeInstanceOf(Promise);
+		expect(/** @type {any} */ (result).then).toBeUndefined();
+	});
+
+	it("streams exactly what the buffer export contains", async () => {
+		/**
+		 * Both exports have to come from the same pass: a second one would be
+		 * signed a moment later and carry different signature bytes.
+		 */
+
+		const pass = buildPass();
+		const stream = pass.getAsStream();
+
+		expect(stream).toBeInstanceOf(Stream);
+
+		const chunks = [];
+
+		for await (const chunk of stream) {
+			chunks.push(chunk);
+		}
+
+		expect(chunks.every(Buffer.isBuffer)).toBe(true);
+		expect(Buffer.concat(chunks).equals(pass.getAsBuffer())).toBe(true);
+	});
+
+	it("returns a frozen map of the same files from getAsRaw", () => {
+		const pass = buildPass();
+		const raw = pass.getAsRaw();
+
+		expect(Object.isFrozen(raw)).toBe(true);
+		expect(Object.keys(raw).sort()).toEqual(
+			[...EXPECTED_FILE_ORDER].sort(),
+		);
+
+		for (const [fileName, buffer] of Object.entries(assets)) {
+			expect(raw[fileName].equals(buffer)).toBe(true);
+		}
+	});
+});

--- a/specs/verifySignature.mjs
+++ b/specs/verifySignature.mjs
@@ -1,0 +1,168 @@
+// @ts-check
+/**
+ * An independent verifier for the detached PKCS#7 signature a pass carries.
+ *
+ * It deliberately shares no code with the signing path: the structure is
+ * walked with node-forge's ASN.1 parser and the RSA check is done by
+ * node:crypto. A bug in the writer therefore cannot be cancelled out by a
+ * matching bug here.
+ */
+
+import forge from "node-forge";
+import crypto from "node:crypto";
+import { Buffer } from "node:buffer";
+
+const OID_SIGNED_DATA = "1.2.840.113549.1.7.2";
+const OID_DATA = "1.2.840.113549.1.7.1";
+const OID_CONTENT_TYPE = "1.2.840.113549.1.9.3";
+const OID_MESSAGE_DIGEST = "1.2.840.113549.1.9.4";
+const OID_SIGNING_TIME = "1.2.840.113549.1.9.5";
+
+/**
+ * @param {Buffer} signature - DER-encoded detached PKCS#7 SignedData
+ * @param {Buffer} manifestBuffer - the content the signature covers
+ * @param {Buffer|string} signerCertPem - PEM of the certificate expected to have signed
+ */
+export function verifyDetachedSignature(
+	signature,
+	manifestBuffer,
+	signerCertPem,
+) {
+	const contentInfo = forge.asn1.fromDer(
+		forge.util.createBuffer(signature.toString("binary")),
+	);
+
+	const contentType = forge.asn1.derToOid(contentInfo.value[0].value);
+
+	if (contentType !== OID_SIGNED_DATA) {
+		throw new Error(`Expected signedData, got OID ${contentType}`);
+	}
+
+	const signedData = contentInfo.value[1].value[0];
+
+	const [, digestAlgorithms, encapContentInfo, ...rest] = signedData.value;
+
+	/** Detached: the encapsulated ContentInfo must carry no content */
+	if (encapContentInfo.value.length > 1) {
+		throw new Error("Signature is not detached: it embeds its content");
+	}
+
+	if (forge.asn1.derToOid(encapContentInfo.value[0].value) !== OID_DATA) {
+		throw new Error("Encapsulated content type is not `data`");
+	}
+
+	const certificates = rest.find(
+		(element) =>
+			element.tagClass === forge.asn1.Class.CONTEXT_SPECIFIC &&
+			element.type === 0,
+	);
+
+	if (!certificates) {
+		throw new Error("Signature carries no certificates");
+	}
+
+	const signerInfos = rest[rest.length - 1];
+	const signerInfo = signerInfos.value[0];
+
+	if (!signerInfo) {
+		throw new Error("Signature carries no signerInfo");
+	}
+
+	const authenticatedAttributes = signerInfo.value.find(
+		(element) =>
+			element.tagClass === forge.asn1.Class.CONTEXT_SPECIFIC &&
+			element.type === 0,
+	);
+
+	if (!authenticatedAttributes) {
+		throw new Error("signerInfo carries no authenticated attributes");
+	}
+
+	const attributesByOid = collectAttributes(authenticatedAttributes);
+
+	for (const [name, oid] of [
+		["contentType", OID_CONTENT_TYPE],
+		["messageDigest", OID_MESSAGE_DIGEST],
+		["signingTime", OID_SIGNING_TIME],
+	]) {
+		if (!attributesByOid.has(oid)) {
+			throw new Error(
+				`Missing required authenticated attribute: ${name}`,
+			);
+		}
+	}
+
+	if (
+		forge.asn1.derToOid(attributesByOid.get(OID_CONTENT_TYPE).value) !==
+		OID_DATA
+	) {
+		throw new Error("contentType attribute is not `data`");
+	}
+
+	/** The messageDigest attribute must equal SHA-1 over the manifest */
+
+	const expectedDigest = crypto
+		.createHash("sha1")
+		.update(manifestBuffer)
+		.digest();
+	const declaredDigest = Buffer.from(
+		attributesByOid.get(OID_MESSAGE_DIGEST).value,
+		"binary",
+	);
+
+	if (!expectedDigest.equals(declaredDigest)) {
+		throw new Error("messageDigest attribute does not cover this manifest");
+	}
+
+	/**
+	 * The signature covers the authenticated attributes re-tagged as a
+	 * universal SET, not as the implicit [0] they appear as on the wire.
+	 */
+
+	const signedAttributesDer = Buffer.from(
+		forge.asn1
+			.toDer(
+				forge.asn1.create(
+					forge.asn1.Class.UNIVERSAL,
+					forge.asn1.Type.SET,
+					true,
+					authenticatedAttributes.value,
+				),
+			)
+			.getBytes(),
+		"binary",
+	);
+
+	const encryptedDigest = Buffer.from(
+		signerInfo.value[signerInfo.value.length - 1].value,
+		"binary",
+	);
+
+	const verified = crypto.verify(
+		"sha1",
+		signedAttributesDer,
+		crypto.createPublicKey(signerCertPem.toString()),
+		encryptedDigest,
+	);
+
+	if (!verified) {
+		throw new Error("RSA verification of the signed attributes failed");
+	}
+
+	return {
+		certificateCount: certificates.value.length,
+		digestAlgorithmCount: digestAlgorithms.value.length,
+		signingTime: attributesByOid.get(OID_SIGNING_TIME).value,
+	};
+}
+
+function collectAttributes(authenticatedAttributes) {
+	const map = new Map();
+
+	for (const attribute of authenticatedAttributes.value) {
+		const oid = forge.asn1.derToOid(attribute.value[0].value);
+		map.set(oid, attribute.value[1].value[0]);
+	}
+
+	return map;
+}

--- a/specs/zipReader.mjs
+++ b/specs/zipReader.mjs
@@ -1,0 +1,168 @@
+// @ts-check
+/**
+ * A deliberately small, dependency-free ZIP reader.
+ *
+ * It only understands STORE (uncompressed) entries, which is all a .pkpass
+ * ever contains. Parsing the archive independently — rather than round-tripping
+ * through the same writer that produced it — is what makes it useful as a
+ * test oracle: a writer bug cannot hide behind a matching reader bug.
+ */
+
+import { Buffer } from "node:buffer";
+
+const LOCAL_HEADER_SIGNATURE = 0x04034b50;
+const CENTRAL_HEADER_SIGNATURE = 0x02014b50;
+const EOCD_SIGNATURE = 0x06054b50;
+
+const CRC_TABLE = (() => {
+	const table = new Int32Array(256);
+
+	for (let n = 0; n < 256; n++) {
+		let c = n;
+
+		for (let k = 0; k < 8; k++) {
+			c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+		}
+
+		table[n] = c;
+	}
+
+	return table;
+})();
+
+/**
+ * @param {Buffer} buffer
+ * @returns {number} unsigned CRC-32
+ */
+export function crc32(buffer) {
+	let sum = -1;
+
+	for (let i = 0; i < buffer.length; i++) {
+		sum = (sum >>> 8) ^ CRC_TABLE[(sum ^ buffer[i]) & 0xff];
+	}
+
+	return (sum ^ -1) >>> 0;
+}
+
+/**
+ * Reads an archive and returns its entries in central-directory order,
+ * asserting the structure as it goes.
+ *
+ * @param {Buffer} archive
+ * @returns {{ entries: { name: string, data: Buffer, crc: number, offset: number }[], eocd: { entryCount: number, centralDirectorySize: number, centralDirectoryOffset: number } }}
+ */
+export function readZip(archive) {
+	const eocdOffset = findEndOfCentralDirectory(archive);
+
+	if (eocdOffset < 0) {
+		throw new Error("End of central directory record not found");
+	}
+
+	const entryCount = archive.readUInt16LE(eocdOffset + 10);
+	const centralDirectorySize = archive.readUInt32LE(eocdOffset + 12);
+	const centralDirectoryOffset = archive.readUInt32LE(eocdOffset + 16);
+
+	if (centralDirectoryOffset + centralDirectorySize !== eocdOffset) {
+		throw new Error(
+			`Central directory does not end where the EOCD begins (${centralDirectoryOffset} + ${centralDirectorySize} !== ${eocdOffset})`,
+		);
+	}
+
+	const entries = [];
+	let cursor = centralDirectoryOffset;
+
+	for (let i = 0; i < entryCount; i++) {
+		if (archive.readUInt32LE(cursor) !== CENTRAL_HEADER_SIGNATURE) {
+			throw new Error(`Bad central directory header at ${cursor}`);
+		}
+
+		const compressionMethod = archive.readUInt16LE(cursor + 10);
+		const crc = archive.readUInt32LE(cursor + 16);
+		const compressedSize = archive.readUInt32LE(cursor + 20);
+		const uncompressedSize = archive.readUInt32LE(cursor + 24);
+		const nameLength = archive.readUInt16LE(cursor + 28);
+		const extraLength = archive.readUInt16LE(cursor + 30);
+		const commentLength = archive.readUInt16LE(cursor + 32);
+		const localOffset = archive.readUInt32LE(cursor + 42);
+		const name = archive
+			.subarray(cursor + 46, cursor + 46 + nameLength)
+			.toString("latin1");
+
+		if (compressionMethod !== 0) {
+			throw new Error(
+				`Entry "${name}" uses compression method ${compressionMethod}; only STORE is supported`,
+			);
+		}
+
+		if (compressedSize !== uncompressedSize) {
+			throw new Error(
+				`Entry "${name}" is stored but its sizes disagree (${compressedSize} vs ${uncompressedSize})`,
+			);
+		}
+
+		/** Cross-check the local header against the central directory */
+
+		if (archive.readUInt32LE(localOffset) !== LOCAL_HEADER_SIGNATURE) {
+			throw new Error(`Bad local header for "${name}" at ${localOffset}`);
+		}
+
+		const localNameLength = archive.readUInt16LE(localOffset + 26);
+		const localExtraLength = archive.readUInt16LE(localOffset + 28);
+		const localName = archive
+			.subarray(localOffset + 30, localOffset + 30 + localNameLength)
+			.toString("latin1");
+
+		if (localName !== name) {
+			throw new Error(
+				`Local header name "${localName}" disagrees with central directory name "${name}"`,
+			);
+		}
+
+		if (archive.readUInt32LE(localOffset + 14) !== crc) {
+			throw new Error(`CRC disagrees between headers for "${name}"`);
+		}
+
+		const dataStart = localOffset + 30 + localNameLength + localExtraLength;
+		const data = archive.subarray(dataStart, dataStart + uncompressedSize);
+
+		if (crc32(data) !== crc) {
+			throw new Error(`CRC mismatch for "${name}"`);
+		}
+
+		entries.push({ name, data, crc, offset: localOffset });
+		cursor += 46 + nameLength + extraLength + commentLength;
+	}
+
+	return {
+		entries,
+		eocd: { entryCount, centralDirectorySize, centralDirectoryOffset },
+	};
+}
+
+/**
+ * Convenience view of an archive as a plain name -> Buffer map.
+ *
+ * @param {Buffer} archive
+ * @returns {{[fileName: string]: Buffer}}
+ */
+export function readZipEntries(archive) {
+	/** @type {{[fileName: string]: Buffer}} */
+	const out = {};
+
+	for (const entry of readZip(archive).entries) {
+		out[entry.name] = entry.data;
+	}
+
+	return out;
+}
+
+function findEndOfCentralDirectory(archive) {
+	/** The EOCD is 22 bytes plus a trailing comment we never write */
+	for (let i = archive.length - 22; i >= 0; i--) {
+		if (archive.readUInt32LE(i) === EOCD_SIGNATURE) {
+			return i;
+		}
+	}
+
+	return -1;
+}

--- a/src/Bundle.ts
+++ b/src/Bundle.ts
@@ -1,6 +1,6 @@
 import { Readable, Stream } from "node:stream";
 import { Buffer } from "node:buffer";
-import { toArray as zipToArray } from "do-not-zip";
+import { createZip } from "./Zip.js";
 import * as Messages from "./messages.js";
 
 export const filesSymbol = Symbol("bundleFiles");
@@ -129,7 +129,7 @@ export default class Bundle {
 
 	public getAsBuffer(): Buffer {
 		this[freezeSymbol]();
-		return Buffer.from(zipToArray(createZipFilesMap(this[filesSymbol])));
+		return createZip(createZipFilesMap(this[filesSymbol]));
 	}
 
 	/**
@@ -142,9 +142,7 @@ export default class Bundle {
 
 	public getAsStream(): Stream {
 		this[freezeSymbol]();
-		return Readable.from(
-			Buffer.from(zipToArray(createZipFilesMap(this[filesSymbol]))),
-		);
+		return Readable.from(createZip(createZipFilesMap(this[filesSymbol])));
 	}
 
 	/**
@@ -164,7 +162,7 @@ export default class Bundle {
 }
 
 /**
- * Creates a files map for do-not-zip
+ * Creates a files map for the zip writer
  *
  * @param files
  * @returns

--- a/src/Signature.ts
+++ b/src/Signature.ts
@@ -1,5 +1,10 @@
-import forge from "node-forge";
-import { createHash as createNativeHash } from "node:crypto";
+import * as asn1js from "asn1js";
+import {
+	createHash as createNativeHash,
+	createPrivateKey,
+	sign as signWithKey,
+	type KeyObject,
+} from "node:crypto";
 import type * as Schemas from "./schemas/index.js";
 import { Buffer } from "node:buffer";
 
@@ -20,11 +25,22 @@ export function createHash(buffer: Buffer) {
 	return createNativeHash("sha1").update(buffer).digest("hex");
 }
 
+const OID = {
+	signedData: "1.2.840.113549.1.7.2",
+	data: "1.2.840.113549.1.7.1",
+	sha1: "1.3.14.3.2.26",
+	rsaEncryption: "1.2.840.113549.1.1.1",
+	contentType: "1.2.840.113549.1.9.3",
+	messageDigest: "1.2.840.113549.1.9.4",
+	signingTime: "1.2.840.113549.1.9.5",
+} as const;
+
+const CONTEXT_SPECIFIC = 3;
+
 /**
  * Decrypting a PEM private key runs the key derivation function that protects
- * it, which is by far the most expensive part of parsing the certificates.
- * A service issuing passes reuses the very same signing key for every pass, so
- * the parsed key is memoized instead of being derived over and over again.
+ * it, and a service issuing passes uses the very same key every time, so the
+ * parsed key is memoized instead of being derived over and over again.
  *
  * The cache is bounded because a multi-tenant issuer may legitimately rotate
  * between several keys, and it is keyed by a digest rather than by the key
@@ -34,7 +50,7 @@ export function createHash(buffer: Buffer) {
 
 const SIGNER_KEY_CACHE_LIMIT = 32;
 
-const signerKeyCache = new Map<string, forge.pki.rsa.PrivateKey>();
+const signerKeyCache = new Map<string, KeyObject>();
 
 function getSignerKeyCacheKey(signerKey: string, passphrase: string): string {
 	/**
@@ -49,10 +65,10 @@ function getSignerKeyCacheKey(signerKey: string, passphrase: string): string {
 		.digest("base64");
 }
 
-function getCachedSignerKey(
+function getSignerKey(
 	signerKey: string,
 	passphrase: string | undefined,
-): forge.pki.rsa.PrivateKey {
+): KeyObject {
 	const cacheKey = getSignerKeyCacheKey(signerKey, passphrase ?? "");
 	const cached = signerKeyCache.get(cacheKey);
 
@@ -64,7 +80,16 @@ function getCachedSignerKey(
 		return cached;
 	}
 
-	const parsedKey = forge.pki.decryptRsaPrivateKey(signerKey, passphrase);
+	/**
+	 * Node accepts PKCS#1, PKCS#8 and encrypted forms of both, and tolerates
+	 * the `Bag Attributes` preamble `openssl pkcs12` writes ahead of the PEM
+	 * block. A wrong or missing passphrase throws here rather than failing
+	 * later with an unusable key.
+	 */
+
+	const parsedKey = passphrase
+		? createPrivateKey({ key: signerKey, passphrase })
+		: createPrivateKey(signerKey);
 
 	if (signerKeyCache.size >= SIGNER_KEY_CACHE_LIMIT) {
 		signerKeyCache.delete(signerKeyCache.keys().next().value as string);
@@ -78,6 +103,11 @@ function getCachedSignerKey(
 /**
  * Generates the PKCS #7 cryptografic signature for the manifest file.
  *
+ * The structure is assembled with asn1js and signed with node:crypto, both of
+ * which are synchronous, so this keeps returning a Buffer rather than a
+ * Promise. A pure-JS RSA implementation was previously responsible for most of
+ * the cost of issuing a pass.
+ *
  * @method create
  * @params manifest
  * @params certificates
@@ -88,16 +118,15 @@ export function create(
 	manifestBuffer: Buffer,
 	certificates: Schemas.CertificatesSchema,
 ): Buffer {
-	const signature = forge.pkcs7.createSignedData();
-
-	signature.content = new forge.util.ByteStringBuffer(manifestBuffer);
-
-	const { wwdr, signerCert, signerKey } = parseCertificates(
-		getStringCertificates(certificates),
+	const wwdr = parseCertificate(bufferToString(certificates.wwdr));
+	const signerCert = parseCertificate(
+		bufferToString(certificates.signerCert),
 	);
 
-	signature.addCertificate(wwdr);
-	signature.addCertificate(signerCert);
+	const signerKey = getSignerKey(
+		bufferToString(certificates.signerKey),
+		certificates.signerKeyPassphrase,
+	);
 
 	/**
 	 * authenticatedAttributes belong to PKCS#9 standard.
@@ -106,84 +135,174 @@ export function create(
 	 * • message-digest oid.
 	 *
 	 * Wallet requires a signingTime.
+	 *
+	 * They are emitted in this order rather than sorted by their encoding:
+	 * verifiers re-encode the attributes exactly as they were parsed, and this
+	 * is the order every pass issued by this library has carried so far.
 	 */
 
-	signature.addSigner({
-		key: signerKey,
-		certificate: signerCert,
-		digestAlgorithm: forge.pki.oids.sha1,
-		authenticatedAttributes: [
-			{
-				type: forge.pki.oids.contentType,
-				value: forge.pki.oids.data,
-			},
-			{
-				type: forge.pki.oids.messageDigest,
-			},
-			{
-				type: forge.pki.oids.signingTime,
-			},
+	const authenticatedAttributes = [
+		createAttribute(
+			OID.contentType,
+			new asn1js.ObjectIdentifier({ value: OID.data }),
+		),
+		createAttribute(
+			OID.messageDigest,
+			new asn1js.OctetString({
+				valueHex: toArrayBuffer(
+					createNativeHash("sha1").update(manifestBuffer).digest(),
+				),
+			}),
+		),
+		createAttribute(
+			OID.signingTime,
+			new asn1js.UTCTime({ valueDate: new Date() }),
+		),
+	];
+
+	/**
+	 * The signature covers the attributes encoded as a plain SET, even though
+	 * they travel inside the signer info under an implicit [0] tag.
+	 */
+
+	const signedAttributes = Buffer.from(
+		new asn1js.Set({ value: authenticatedAttributes }).toBER(false),
+	);
+
+	const signature = signWithKey("sha1", signedAttributes, signerKey);
+
+	const signerInfo = new asn1js.Sequence({
+		value: [
+			new asn1js.Integer({ value: 1 }),
+			new asn1js.Sequence({
+				value: [signerCert.issuer, signerCert.serialNumber],
+			}),
+			createAlgorithmIdentifier(OID.sha1),
+			new asn1js.Constructed({
+				idBlock: { tagClass: CONTEXT_SPECIFIC, tagNumber: 0 },
+				value: authenticatedAttributes,
+			}),
+			createAlgorithmIdentifier(OID.rsaEncryption),
+			new asn1js.OctetString({ valueHex: toArrayBuffer(signature) }),
 		],
 	});
 
 	/**
-	 * We are creating a detached signature because we don't need the signed content.
+	 * We are creating a detached signature because we don't need the signed
+	 * content: the encapsulated ContentInfo carries its type and nothing else.
 	 * Detached signature is a property of PKCS#7 cryptography standard.
 	 */
 
-	signature.sign({ detached: true });
+	const signedData = new asn1js.Sequence({
+		value: [
+			new asn1js.Integer({ value: 1 }),
+			new asn1js.Set({ value: [createAlgorithmIdentifier(OID.sha1)] }),
+			new asn1js.Sequence({
+				value: [new asn1js.ObjectIdentifier({ value: OID.data })],
+			}),
+			new asn1js.Constructed({
+				idBlock: { tagClass: CONTEXT_SPECIFIC, tagNumber: 0 },
+				value: [wwdr.certificate, signerCert.certificate],
+			}),
+			new asn1js.Set({ value: [signerInfo] }),
+		],
+	});
+
+	const contentInfo = new asn1js.Sequence({
+		value: [
+			new asn1js.ObjectIdentifier({ value: OID.signedData }),
+			new asn1js.Constructed({
+				idBlock: { tagClass: CONTEXT_SPECIFIC, tagNumber: 0 },
+				value: [signedData],
+			}),
+		],
+	});
+
+	return Buffer.from(contentInfo.toBER(false));
+}
+
+function createAlgorithmIdentifier(oid: string): asn1js.Sequence {
+	return new asn1js.Sequence({
+		value: [new asn1js.ObjectIdentifier({ value: oid }), new asn1js.Null()],
+	});
+}
+
+function createAttribute(oid: string, value: asn1js.AsnType): asn1js.Sequence {
+	return new asn1js.Sequence({
+		value: [
+			new asn1js.ObjectIdentifier({ value: oid }),
+			new asn1js.Set({ value: [value] }),
+		],
+	});
+}
+
+interface ParsedCertificate {
+	certificate: asn1js.AsnType;
+	issuer: asn1js.AsnType;
+	serialNumber: asn1js.AsnType;
+}
+
+const PEM_CERTIFICATE =
+	/-----BEGIN CERTIFICATE-----([A-Za-z0-9+/=\s]+?)-----END CERTIFICATE-----/;
+
+/**
+ * Reads a PEM certificate and picks out the two fields the signer info has to
+ * name: the issuer and the serial number. Anything ahead of the PEM block —
+ * such as the `Bag Attributes` preamble — is ignored, and when a file holds a
+ * chain only the first certificate is used.
+ */
+
+function parseCertificate(pem: string): ParsedCertificate {
+	const match = PEM_CERTIFICATE.exec(pem);
+
+	if (!match) {
+		throw new Error(
+			"Invalid certificate: no PEM certificate block was found.",
+		);
+	}
+
+	const der = Buffer.from(match[1].replace(/\s+/g, ""), "base64");
+	const { result, offset } = asn1js.fromBER(toArrayBuffer(der));
+
+	if (offset === -1) {
+		throw new Error("Invalid certificate: could not be parsed as DER.");
+	}
+
+	const tbsCertificate = (result as asn1js.Sequence).valueBlock
+		.value[0] as asn1js.Sequence;
+	const fields = tbsCertificate.valueBlock.value;
 
 	/**
-	 * Signature here is an ASN.1 valid structure (DER-compliant).
-	 * Generating a non-detached signature, would have pushed inside signature.contentInfo
-	 * (which has type 16, or "SEQUENCE", and is an array) a Context-Specific element, with the
-	 * signed content as value.
-	 *
-	 * In fact the previous approach was to generating a detached signature and the pull away the generated
-	 * content.
-	 *
-	 * That's what happens when you copy a fu****g line without understanding what it does.
-	 * Well, nevermind, it was funny to study BER, DER, CER, ASN.1 and PKCS#7. You can learn a lot
-	 * of beautiful things. ¯\_(ツ)_/¯
+	 * `version` is an optional [0] EXPLICIT field. When it is absent the
+	 * certificate is v1 and `serialNumber` comes first instead.
 	 */
 
-	return Buffer.from(
-		forge.asn1.toDer(signature.toAsn1()).getBytes(),
-		"binary",
-	);
+	const hasVersion =
+		fields[0].idBlock.tagClass === CONTEXT_SPECIFIC &&
+		fields[0].idBlock.tagNumber === 0;
+	const serialNumberIndex = hasVersion ? 1 : 0;
+
+	/** TBSCertificate ::= { [version,] serialNumber, signature, issuer, ... } */
+
+	return {
+		certificate: result,
+		serialNumber: fields[serialNumberIndex],
+		issuer: fields[serialNumberIndex + 2],
+	};
+}
+
+function bufferToString(source: string | Buffer): string {
+	return Buffer.isBuffer(source) ? source.toString("utf-8") : source;
 }
 
 /**
- * Parses the PEM-formatted passed text (certificates)
- *
- * @param element - Text content of .pem files
- * @param passphrase - passphrase for the key
- * @returns The parsed certificate or key in node forge format
+ * asn1js works on ArrayBuffers. A Buffer is frequently a window onto a larger
+ * shared pool, so the region it actually owns has to be copied out.
  */
 
-function parseCertificates(certificates: Schemas.CertificatesSchema) {
-	const { signerCert, signerKey, wwdr, signerKeyPassphrase } = certificates;
-
-	return {
-		signerCert: forge.pki.certificateFromPem(signerCert.toString("utf-8")),
-		wwdr: forge.pki.certificateFromPem(wwdr.toString("utf-8")),
-		signerKey: getCachedSignerKey(
-			signerKey.toString("utf-8"),
-			signerKeyPassphrase,
-		),
-	};
-}
-
-function getStringCertificates(
-	certificates: Schemas.CertificatesSchema,
-): Record<
-	keyof Omit<Schemas.CertificatesSchema, "signerKeyPassphrase">,
-	string
-> & { signerKeyPassphrase?: string } {
-	return {
-		signerKeyPassphrase: certificates.signerKeyPassphrase,
-		wwdr: Buffer.from(certificates.wwdr).toString("utf-8"),
-		signerCert: Buffer.from(certificates.signerCert).toString("utf-8"),
-		signerKey: Buffer.from(certificates.signerKey).toString("utf-8"),
-	};
+function toArrayBuffer(buffer: Buffer): ArrayBuffer {
+	return buffer.buffer.slice(
+		buffer.byteOffset,
+		buffer.byteOffset + buffer.byteLength,
+	) as ArrayBuffer;
 }

--- a/src/Signature.ts
+++ b/src/Signature.ts
@@ -1,4 +1,5 @@
 import forge from "node-forge";
+import { createHash as createNativeHash } from "node:crypto";
 import type * as Schemas from "./schemas/index.js";
 import { Buffer } from "node:buffer";
 
@@ -14,6 +15,61 @@ export function createHash(buffer: Buffer) {
 	hashFlow.update(buffer.toString("binary"));
 
 	return hashFlow.digest().toHex();
+}
+
+/**
+ * Decrypting a PEM private key runs the key derivation function that protects
+ * it, which is by far the most expensive part of parsing the certificates.
+ * A service issuing passes reuses the very same signing key for every pass, so
+ * the parsed key is memoized instead of being derived over and over again.
+ *
+ * The cache is bounded because a multi-tenant issuer may legitimately rotate
+ * between several keys, and it is keyed by a digest rather than by the key
+ * material itself so that neither the PEM nor the passphrase is retained in a
+ * long-lived structure.
+ */
+
+const SIGNER_KEY_CACHE_LIMIT = 32;
+
+const signerKeyCache = new Map<string, forge.pki.rsa.PrivateKey>();
+
+function getSignerKeyCacheKey(signerKey: string, passphrase: string): string {
+	/**
+	 * Both fields are length-prefixed so that no two different
+	 * (key, passphrase) pairs can produce the same digest input.
+	 */
+
+	return createNativeHash("sha256")
+		.update(
+			`${signerKey.length}:${signerKey}:${passphrase.length}:${passphrase}`,
+		)
+		.digest("base64");
+}
+
+function getCachedSignerKey(
+	signerKey: string,
+	passphrase: string | undefined,
+): forge.pki.rsa.PrivateKey {
+	const cacheKey = getSignerKeyCacheKey(signerKey, passphrase ?? "");
+	const cached = signerKeyCache.get(cacheKey);
+
+	if (cached) {
+		/** Re-inserting refreshes recency, so the map evicts least-recently-used */
+		signerKeyCache.delete(cacheKey);
+		signerKeyCache.set(cacheKey, cached);
+
+		return cached;
+	}
+
+	const parsedKey = forge.pki.decryptRsaPrivateKey(signerKey, passphrase);
+
+	if (signerKeyCache.size >= SIGNER_KEY_CACHE_LIMIT) {
+		signerKeyCache.delete(signerKeyCache.keys().next().value as string);
+	}
+
+	signerKeyCache.set(cacheKey, parsedKey);
+
+	return parsedKey;
 }
 
 /**
@@ -108,7 +164,7 @@ function parseCertificates(certificates: Schemas.CertificatesSchema) {
 	return {
 		signerCert: forge.pki.certificateFromPem(signerCert.toString("utf-8")),
 		wwdr: forge.pki.certificateFromPem(wwdr.toString("utf-8")),
-		signerKey: forge.pki.decryptRsaPrivateKey(
+		signerKey: getCachedSignerKey(
 			signerKey.toString("utf-8"),
 			signerKeyPassphrase,
 		),

--- a/src/Signature.ts
+++ b/src/Signature.ts
@@ -6,15 +6,18 @@ import { Buffer } from "node:buffer";
 /**
  * Creates an hash for a buffer. Used by manifest
  *
+ * Node's SHA-1 hashes the buffer directly, where the previous pure-JS
+ * implementation had to first widen every byte into a latin1 string. Both
+ * produce the same digest — latin1 is a lossless byte-to-character mapping —
+ * but hashing a manifest's worth of image data natively is around twenty
+ * times cheaper.
+ *
  * @param buffer
  * @returns
  */
 
 export function createHash(buffer: Buffer) {
-	const hashFlow = forge.md.sha1.create();
-	hashFlow.update(buffer.toString("binary"));
-
-	return hashFlow.digest().toHex();
+	return createNativeHash("sha1").update(buffer).digest("hex");
 }
 
 /**

--- a/src/Zip.ts
+++ b/src/Zip.ts
@@ -1,0 +1,191 @@
+import { Buffer } from "node:buffer";
+import zlib from "node:zlib";
+
+/**
+ * A minimal, linear ZIP writer.
+ *
+ * Every entry is written with the STORE method: a .pkpass is almost entirely
+ * PNG data, which is already deflated, so compressing it again costs time and
+ * saves nothing.
+ *
+ * The archive is sized up front and written once into a single Buffer. The
+ * previous implementation rebuilt a plain JavaScript array of numbers for the
+ * whole archive on every file, which made assembling a bundle quadratic in its
+ * total size.
+ *
+ * The byte layout is deliberately identical to the one this replaces, so
+ * existing bundles stay reproducible byte for byte.
+ */
+
+export interface ZipEntry {
+	path: string;
+	data: Buffer;
+}
+
+const LOCAL_HEADER_SIZE = 30;
+const CENTRAL_HEADER_SIZE = 46;
+const END_OF_CENTRAL_DIRECTORY_SIZE = 22;
+
+const LOCAL_HEADER_SIGNATURE = 0x04034b50;
+const CENTRAL_HEADER_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+
+/** Version 1.0: the lowest that can describe a stored, unencrypted entry */
+const VERSION_NEEDED_TO_EXTRACT = 0x000a;
+const VERSION_MADE_BY = 0x0014;
+const METHOD_STORE = 0;
+
+/**
+ * File names are written the same way they were before: one byte per code
+ * unit. Pass bundles only ever contain ASCII names — the asset names Wallet
+ * expects, plus `<lang>.lproj/pass.strings` — so this is lossless in practice,
+ * and keeping it means archives stay byte-identical to previously issued ones.
+ */
+const FILE_NAME_ENCODING = "latin1";
+
+/**
+ * node:zlib gained a native crc32 in Node 20.15. Falling back to a table keeps
+ * the writer working on older runtimes and on environments that ship a reduced
+ * zlib, at the cost of a millisecond or so per bundle.
+ */
+const nativeCrc32 = (zlib as unknown as { crc32?: (data: Buffer) => number })
+	.crc32;
+
+const CRC_TABLE = /* @__PURE__ */ (() => {
+	const table = new Int32Array(256);
+
+	for (let n = 0; n < 256; n++) {
+		let c = n;
+
+		for (let k = 0; k < 8; k++) {
+			c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+		}
+
+		table[n] = c;
+	}
+
+	return table;
+})();
+
+function crc32(data: Buffer): number {
+	if (nativeCrc32) {
+		return nativeCrc32(data) >>> 0;
+	}
+
+	let sum = -1;
+
+	for (let i = 0; i < data.length; i++) {
+		sum = (sum >>> 8) ^ CRC_TABLE[(sum ^ data[i]) & 0xff];
+	}
+
+	return (sum ^ -1) >>> 0;
+}
+
+/**
+ * Writes the 26 bytes local and central headers share, starting at `offset`.
+ * Fields left at zero — flags, modification time and date, extra field length —
+ * are already zero because the archive is allocated zero-filled.
+ *
+ * @returns the offset just past the block that was written
+ */
+
+function writeCommonHeader(
+	archive: Buffer,
+	offset: number,
+	crc: number,
+	size: number,
+	fileNameLength: number,
+): number {
+	archive.writeUInt16LE(VERSION_NEEDED_TO_EXTRACT, offset);
+	archive.writeUInt16LE(METHOD_STORE, offset + 4);
+	archive.writeUInt32LE(crc, offset + 10);
+	/** Stored entries are their own compressed form, so both sizes agree */
+	archive.writeUInt32LE(size, offset + 14);
+	archive.writeUInt32LE(size, offset + 18);
+	archive.writeUInt16LE(fileNameLength, offset + 22);
+
+	return offset + 26;
+}
+
+/**
+ * Packs the given entries into a ZIP archive.
+ *
+ * @param entries - files to store, in the order they should appear
+ * @returns the complete archive
+ */
+
+export function createZip(entries: ZipEntry[]): Buffer {
+	const fileNames: Buffer[] = new Array(entries.length);
+	const checksums: number[] = new Array(entries.length);
+
+	let localSectionSize = 0;
+	let centralDirectorySize = 0;
+
+	for (let i = 0; i < entries.length; i++) {
+		const { path, data } = entries[i];
+		const fileName = Buffer.from(path, FILE_NAME_ENCODING);
+
+		fileNames[i] = fileName;
+		checksums[i] = crc32(data);
+
+		localSectionSize += LOCAL_HEADER_SIZE + fileName.length + data.length;
+		centralDirectorySize += CENTRAL_HEADER_SIZE + fileName.length;
+	}
+
+	const archive = Buffer.alloc(
+		localSectionSize + centralDirectorySize + END_OF_CENTRAL_DIRECTORY_SIZE,
+	);
+
+	let localOffset = 0;
+	let centralOffset = localSectionSize;
+
+	for (let i = 0; i < entries.length; i++) {
+		const { data } = entries[i];
+		const fileName = fileNames[i];
+		const crc = checksums[i];
+
+		/** The entry's own offset, recorded before the header is laid down */
+		const entryOffset = localOffset;
+
+		archive.writeUInt32LE(LOCAL_HEADER_SIGNATURE, localOffset);
+		localOffset = writeCommonHeader(
+			archive,
+			localOffset + 4,
+			crc,
+			data.length,
+			fileName.length,
+		);
+
+		localOffset += fileName.copy(archive, localOffset);
+		localOffset += data.copy(archive, localOffset);
+
+		archive.writeUInt32LE(CENTRAL_HEADER_SIGNATURE, centralOffset);
+		archive.writeUInt16LE(VERSION_MADE_BY, centralOffset + 4);
+
+		const afterCommon = writeCommonHeader(
+			archive,
+			centralOffset + 6,
+			crc,
+			data.length,
+			fileName.length,
+		);
+
+		/**
+		 * The ten bytes between the shared header and the offset — comment
+		 * length, disk number, and the internal and external attributes —
+		 * stay zero.
+		 */
+
+		archive.writeUInt32LE(entryOffset, afterCommon + 10);
+		centralOffset = afterCommon + 14;
+		centralOffset += fileName.copy(archive, centralOffset);
+	}
+
+	archive.writeUInt32LE(END_OF_CENTRAL_DIRECTORY_SIGNATURE, centralOffset);
+	archive.writeUInt16LE(entries.length, centralOffset + 8);
+	archive.writeUInt16LE(entries.length, centralOffset + 10);
+	archive.writeUInt32LE(centralDirectorySize, centralOffset + 12);
+	archive.writeUInt32LE(localSectionSize, centralOffset + 16);
+
+	return archive;
+}


### PR DESCRIPTION
## Description

Generating a pass is currently dominated by four independent hot spots, all of which
are avoidable without changing a single public signature. This series removes them
one at a time, smallest and safest first.

I hit this running Wallet passes in production: pass generation was the bottleneck in
the pipeline, and because the whole build is synchronous it blocked the event loop for
its entire duration, which is what actually hurts on a server.

Measured on a ten-file, ~450KB PNG bundle with an RSA-2048 key and two localizations.
These are Apple Silicon numbers, so the ratios are the transferable part, not the
absolutes:

| stage | mean | p95 | throughput | max event-loop block |
| --- | --- | --- | --- | --- |
| before | 62.77ms | 68.91ms | 16.3/s | 140.4ms |
| + signer key cache | 43.37ms | 47.36ms | 23.1/s | 74.1ms |
| + native SHA-1 | 38.69ms | 43.73ms | 26.1/s | 60.2ms |
| + linear zip writer | 19.59ms | 20.26ms | 51.8/s | 42.3ms |
| + native PKCS#7 | **1.24ms** | 1.46ms | **835.9/s** | **1.7ms** |

Roughly **50x** on per-pass latency and throughput, and ~80x on worst-case event-loop
blocking.

### The four commits

Each one is a separate commit that builds and passes the suite on its own, so they can
be reviewed — or merged — independently.

1. **Cache the parsed signer key.** The PEM was decrypted once per pass, re-running the
   key derivation function every time. Bounded to 32 entries, LRU-evicted, and keyed by
   a SHA-256 digest rather than the key material, so neither the PEM nor the passphrase
   is retained in a long-lived structure.
2. **Hash the manifest with `node:crypto`.** The manifest is a SHA-1 over every file in
   the bundle. Doing that in pure JS, via a latin1 string widened from the buffer,
   dominated hashing cost. latin1 is a lossless byte-to-character mapping, so the digest
   is unchanged.
3. **Replace `do-not-zip` with a linear zip writer.** `do-not-zip` does, per file:
   `fileData = [...fileData, 0x50, 0x4B, ..., ...dataBytes]` — rebuilding the entire
   archive in a plain JS array of numbers rather than a Buffer. ~450KB becomes ~450,000
   boxed numbers re-spread once per file: quadratic in bundle size, with heavy GC
   pressure. The replacement sizes the archive up front and writes it once into a single
   zero-filled Buffer, STORE-only (a pass is mostly PNG data that is already deflated).
4. **Sign with `node:crypto` instead of `node-forge`.** Pure-JS RSA was the single most
   expensive step — ~18.5ms per pass on its own. The SignedData is assembled with
   `asn1js` and signed with `crypto.sign()`.

## Check relevant checkboxes

-   [x] I've run tests (through `npm test`) and they passed
-   [ ] I generated a working Apple Wallet Pass after the change
-   [ ] Provided examples keep working after the change
-   [ ] This improvement is or might be a breaking change

Rather than guessing at the three unchecked boxes:

- **Wallet pass on a device** — I generated complete `.pkpass` bundles and verified them
  with `openssl smime -verify` including full chain validation, an independent ASN.1
  walk that checks RSA via `node:crypto`, `unzip -t`, and by confirming every manifest
  digest matches the actual file bytes. But that was with *ephemeral* certificates, not
  real Apple signing material on a real device.
- **Examples** — not executed. Indirect evidence instead: the generated `lib/types` are
  byte-identical to `master` for every pre-existing declaration — `index.d.ts`,
  `PKPass.d.ts` and `Bundle.d.ts` all diff clean — so nothing the examples consume
  changed shape. The only additions are doc comments and a new internal `Zip.d.ts`,
  which `index.d.ts` does not export.
- **Breaking change** — the public API is not breaking, and that is asserted by a test
  rather than assumed. See *Runtime requirements* below for the one thing that does
  genuinely shift.

## Relevant information

### The constraint that shaped this

`getAsBuffer()` is synchronous, and I wanted to keep it that way. A `pkijs` + WebCrypto
signer forces it to return a `Promise`, which is a breaking change for every caller and
a major version bump. `asn1js` encodes DER synchronously and `crypto.sign()` is
synchronous, so the whole path stays sync and this can land as a patch/minor.
`specs/output.spec.mjs` asserts the synchronous contract directly.

### Output is unchanged, and that is tested

The digests, file list and ordering pinned in `specs/output.spec.mjs` were captured from
an unmodified **3.5.7** before any of this work landed. Because the manifest is a SHA-1
of every other file, pinning it pins the exact bytes of `pass.json` and of each
`pass.strings` transitively, not merely their presence.

- **Zip** — byte-identical to `do-not-zip` across empty archives, empty entries, names
  longer than 255 bytes, multi-megabyte payloads and realistic bundles. Previously
  issued archives stay reproducible byte for byte.
- **Signature** — structurally identical to `node-forge`'s output. The
  `issuerAndSerialNumber`, both algorithm identifiers and the embedded certificate block
  are byte-identical; only `signingTime` and the signature bytes differ, as they do
  between any two runs of the *same* implementation.

Two deliberately conservative calls, both worth pushing back on if you disagree:

- **Authenticated attributes keep node-forge's insertion order** (contentType,
  messageDigest, signingTime) instead of being sorted as strict DER would require.
  Verifiers re-encode attributes exactly as parsed, and this is the order every pass
  issued by this library so far has carried, so re-sorting seemed like gratuitous risk
  for no gain.
- **File names stay latin1-encoded**, matching `do-not-zip`. This mangles non-ASCII
  names, but pass bundles are ASCII in practice, and fixing it is a behaviour change
  that does not belong in a performance PR. Happy to open a separate issue.

### Runtime requirements

The one thing that actually shifts, so flagging it explicitly:

- `zlib.crc32` is used when available (Node 20.15+) and falls back to a lookup table
  otherwise, so `engines: >=14.21.3` is **not** tightened.
- The signing path needs `crypto.createPrivateKey` and `crypto.sign`. On Node those are
  ancient. On **Cloudflare Workers**, the full `node:crypto` API landed in April 2025
  and requires only the `nodejs_compat` flag, which `examples/cloudflare-worker` already
  sets — so no `compatibility_date` bump should be needed. I was not able to execute
  that example to confirm, and it is the part I would most like a second opinion on.

### Dependencies

Runtime dependencies go from `do-not-zip, joi, node-forge, tslib` to
`asn1js, joi, tslib`, replacing `node-forge` with a considerably smaller tree.

`node-forge` and `do-not-zip` are retained as **devDependencies** and still earn their
place: forge generates ephemeral test certificates and verifies signatures independently
of the code that writes them, and `do-not-zip` backs the byte-compatibility assertions.
Producing with one stack and verifying with another is deliberate — a bug in the writer
cannot be cancelled out by a matching bug in the checker.

### Tests

101 passing. `specs/` gains:

- a dependency-free ZIP reader used as a test oracle;
- an independent PKCS#7 verifier that shares no code with the signing path;
- ephemeral certificate generation, so no real signing material is ever needed;
- coverage for tampered manifests, encrypted PKCS#8 keys with a `Bag Attributes`
  preamble, legacy encrypted PEMs, and wrong or missing passphrases.

Note the existing suite needs a WWDR certificate via the `WWDR` env var (or
`certificates/WWDR.pem`), which a fresh clone does not have. The new specs generate
their own certificates and need neither.

### On splitting this up

If four changes in one PR is too much at once, say the word and I will split it into
four stacked PRs — the commits are already separated for exactly that, and each builds
and passes the suite independently. The zip writer (commit 3) is the most self-contained
of them and has no crypto surface at all, so it may be the easiest starting point.